### PR TITLE
Prep deletion of redundant code getScreenOrientation

### DIFF
--- a/android/app/src/main/java/org/openbot/original/CameraActivity.java
+++ b/android/app/src/main/java/org/openbot/original/CameraActivity.java
@@ -849,6 +849,11 @@ public abstract class CameraActivity extends AppCompatActivity
     }
   }
 
+  /**
+   * @deprecated redundant code, candidate for deletion for next release, use
+   *     ImageUtils.getScreenOrientation() instead.
+   */
+  @Deprecated
   protected int getScreenOrientation() {
     switch (getWindowManager().getDefaultDisplay().getRotation()) {
       case Surface.ROTATION_270:

--- a/android/app/src/main/java/org/openbot/original/CameraActivity.java
+++ b/android/app/src/main/java/org/openbot/original/CameraActivity.java
@@ -49,7 +49,6 @@ import android.os.SystemClock;
 import android.os.Trace;
 import android.util.Log;
 import android.util.Size;
-import android.view.Surface;
 import android.view.View;
 import android.view.ViewTreeObserver;
 import android.view.WindowManager;
@@ -846,24 +845,6 @@ public abstract class CameraActivity extends AppCompatActivity
   protected void readyForNextImage() {
     if (postInferenceCallback != null) {
       postInferenceCallback.run();
-    }
-  }
-
-  /**
-   * @deprecated redundant code, candidate for deletion for next release, use
-   *     ImageUtils.getScreenOrientation() instead.
-   */
-  @Deprecated
-  protected int getScreenOrientation() {
-    switch (getWindowManager().getDefaultDisplay().getRotation()) {
-      case Surface.ROTATION_270:
-        return 270;
-      case Surface.ROTATION_180:
-        return 180;
-      case Surface.ROTATION_90:
-        return 90;
-      default:
-        return 0;
     }
   }
 

--- a/android/app/src/main/java/org/openbot/original/DefaultActivity.java
+++ b/android/app/src/main/java/org/openbot/original/DefaultActivity.java
@@ -104,7 +104,7 @@ public class DefaultActivity extends CameraActivity implements OnImageAvailableL
     previewWidth = size.getWidth();
     previewHeight = size.getHeight();
 
-    sensorOrientation = rotation - getScreenOrientation();
+    sensorOrientation = rotation - ImageUtils.getScreenOrientation(this);
     LOGGER.i("Camera orientation relative to screen canvas: %d", sensorOrientation);
 
     LOGGER.i("Initializing at size %dx%d", previewWidth, previewHeight);


### PR DESCRIPTION
The code in CameraActivity is redundant with same methode in ImageUtils and only 1 time used.
Could be deleted without risk.
In this commit I just marked it deprecated (for later deletion)