### PR TITLE
Get DEFAULT camera lens facing from shared preferences,

### DIFF
--- a/android/app/src/main/java/org/openbot/common/CameraFragment.java
+++ b/android/app/src/main/java/org/openbot/common/CameraFragment.java
@@ -27,6 +27,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.openbot.R;
 import org.openbot.env.ImageUtils;
+import org.openbot.env.SharedPreferencesManager;
 import org.openbot.utils.Constants;
 import org.openbot.utils.Enums;
 import org.openbot.utils.PermissionUtils;
@@ -38,7 +39,7 @@ public abstract class CameraFragment extends ControlsFragment {
   private ExecutorService cameraExecutor;
   private PreviewView previewView;
   private Preview preview;
-  protected static int lensFacing = CameraSelector.LENS_FACING_BACK;
+  protected int lensFacing = CameraSelector.LENS_FACING_BACK; // altered by shared preferences
   private ProcessCameraProvider cameraProvider;
   private Size analyserResolution = Enums.Preview.HD.getValue();
   private YuvToRgbConverter converter;
@@ -79,6 +80,9 @@ public abstract class CameraFragment extends ControlsFragment {
 
   @SuppressLint("RestrictedApi")
   private void setupCamera() {
+    // get default camera facing to use from preferences
+    lensFacing = new SharedPreferencesManager(getContext()).getCameraFacing();
+
     ListenableFuture<ProcessCameraProvider> cameraProviderFuture =
         ProcessCameraProvider.getInstance(requireContext());
 

--- a/android/app/src/main/java/org/openbot/env/SharedPreferencesManager.java
+++ b/android/app/src/main/java/org/openbot/env/SharedPreferencesManager.java
@@ -2,6 +2,7 @@ package org.openbot.env;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import androidx.camera.core.CameraSelector;
 import org.openbot.tflite.Network;
 import org.openbot.utils.Enums;
 
@@ -32,6 +33,7 @@ public class SharedPreferencesManager {
   private static final int DEFAULT_NUM_THREAD = 4;
   private static final String NUM_THREAD = "NUM_THREAD";
   private static final String CAMERA_SWITCH = "CAMERA_SWITCH";
+  public static final String CAMERA_FACING = "camera_lens_facing";
   private static final String SHEET_EXPANDED = "SHEET_EXPANDED";
   private static final String DELAY = "DELAY";
 
@@ -72,8 +74,14 @@ public class SharedPreferencesManager {
     return preferences.getInt(NUM_THREAD, DEFAULT_NUM_THREAD);
   }
 
+  /**
+   * Used in bottom sheet manual camera toggle, depends on shared preference for camera lens facing
+   *
+   * @return true for front camera otherwise false
+   */
   public boolean getCameraSwitch() {
-    return preferences.getBoolean(CAMERA_SWITCH, false);
+    return getCameraFacing() == CameraSelector.LENS_FACING_FRONT;
+    // return preferences.getBoolean(CAMERA_SWITCH, false);
   }
 
   public boolean getSheetExpanded() {
@@ -150,6 +158,28 @@ public class SharedPreferencesManager {
 
   public void setCameraSwitch(boolean isChecked) {
     preferences.edit().putBoolean(CAMERA_SWITCH, isChecked).apply();
+  }
+
+  /**
+   * Set/remember default camera facing
+   *
+   * @param cameraFacing int CameraSelector.LENS_FACING_BACK=1 or LENS_FACING_FRONT=0
+   */
+  public void setCameraFacing(int cameraFacing) {
+    if (cameraFacing == CameraSelector.LENS_FACING_FRONT)
+      preferences.edit().putBoolean(CAMERA_FACING, true).apply();
+    else preferences.edit().putBoolean(CAMERA_FACING, false).apply();
+  }
+
+  /**
+   * Get default camera facing. If not set default is LENS_FACING_BACK
+   *
+   * @return CameraSelector.LENS_FACING_BACK or LENS_FACING_FRONT
+   */
+  public int getCameraFacing() {
+    boolean facingswitch = preferences.getBoolean(CAMERA_FACING, false);
+    if (facingswitch) return CameraSelector.LENS_FACING_FRONT;
+    else return CameraSelector.LENS_FACING_BACK;
   }
 
   public void setSheetExpanded(boolean expanded) {

--- a/android/app/src/main/java/org/openbot/main/SettingsFragment.java
+++ b/android/app/src/main/java/org/openbot/main/SettingsFragment.java
@@ -16,11 +16,13 @@ import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
+import androidx.camera.core.CameraSelector;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.preference.ListPreference;
 import androidx.preference.PreferenceFragmentCompat;
 import androidx.preference.SwitchPreferenceCompat;
 import org.openbot.R;
+import org.openbot.env.SharedPreferencesManager;
 import org.openbot.utils.Constants;
 import org.openbot.utils.PermissionUtils;
 import org.openbot.vehicle.Vehicle;
@@ -34,6 +36,7 @@ public class SettingsFragment extends PreferenceFragmentCompat {
   private SwitchPreferenceCompat storage;
   private SwitchPreferenceCompat location;
   private SwitchPreferenceCompat mic;
+  private SwitchPreferenceCompat cameralensfacing;
 
   private final ActivityResultLauncher<String[]> requestPermissionLauncher =
       registerForActivityResult(
@@ -187,6 +190,21 @@ public class SettingsFragment extends PreferenceFragmentCompat {
               } else requestPermissionLauncher.launch(new String[] {Constants.PERMISSION_AUDIO});
             }
             return false;
+          });
+    }
+
+    // Default camera to use (Back or Front camera)
+    cameralensfacing = findPreference(SharedPreferencesManager.CAMERA_FACING);
+    if (cameralensfacing != null) {
+      cameralensfacing.setOnPreferenceClickListener(
+          preference -> {
+            if (cameralensfacing.isChecked())
+              new SharedPreferencesManager(getContext())
+                  .setCameraFacing(CameraSelector.LENS_FACING_FRONT);
+            else
+              new SharedPreferencesManager(getContext())
+                  .setCameraFacing(CameraSelector.LENS_FACING_BACK);
+            return true;
           });
     }
 

--- a/android/app/src/main/java/org/openbot/original/CameraActivity.java
+++ b/android/app/src/main/java/org/openbot/original/CameraActivity.java
@@ -851,7 +851,8 @@ public abstract class CameraActivity extends AppCompatActivity
   protected int getCameraUserSelection() {
     // during initialisation there is no cameraToggle so we assume default
     if (this.cameraSwitchCompat == null) {
-      this.cameraSelection = CameraCharacteristics.LENS_FACING_BACK;
+      // use default from preferences
+      this.cameraSelection = new SharedPreferencesManager(getContext()).getCameraFacing();
     } else {
       this.cameraSelection = this.cameraSwitchCompat.isChecked() ? 0 : 1;
     }

--- a/android/app/src/main/res/xml/root_preferences.xml
+++ b/android/app/src/main/res/xml/root_preferences.xml
@@ -35,6 +35,14 @@
             app:title="Microphone" />
     </PreferenceCategory>
 
+    <PreferenceCategory app:title="@string/camera">
+
+        <SwitchPreferenceCompat
+            app:key="camera_lens_facing"
+            app:title="Use camera facing front" />
+
+    </PreferenceCategory>
+
     <PreferenceCategory app:title="Video Streaming">
 
         <ListPreference


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
Some (me) use robot app front camera for object tracking etc.. 
This has to be manually toggled each time the app is started.

**Describe the solution you'd like**
Would like to define the DEFAULT camera lens facing direction to use in the preferences.

**Description of changes**
Pull request implements a shared preference setting for the default camera facing.
It leaves the bottom sheet toggle camera switch as is, so camera can be switched manually as usual without altering the preference setting.
On next start of the robot app the default from shared preferences is used.