### PR TITLE
Harmonize use of preference CAMERA_SWITCH by bottom sheets

### DIFF
--- a/android/app/src/main/java/org/openbot/common/CameraFragment.java
+++ b/android/app/src/main/java/org/openbot/common/CameraFragment.java
@@ -38,7 +38,7 @@ public abstract class CameraFragment extends ControlsFragment {
   private ExecutorService cameraExecutor;
   private PreviewView previewView;
   private Preview preview;
-  protected int lensFacing; // init val set from prefs
+  protected int lensFacing;
   private ProcessCameraProvider cameraProvider;
   private Size analyserResolution = Enums.Preview.HD.getValue();
   private YuvToRgbConverter converter;

--- a/android/app/src/main/java/org/openbot/common/CameraFragment.java
+++ b/android/app/src/main/java/org/openbot/common/CameraFragment.java
@@ -38,7 +38,7 @@ public abstract class CameraFragment extends ControlsFragment {
   private ExecutorService cameraExecutor;
   private PreviewView previewView;
   private Preview preview;
-  protected static int lensFacing = CameraSelector.LENS_FACING_BACK;
+  protected int lensFacing; // init val set from prefs
   private ProcessCameraProvider cameraProvider;
   private Size analyserResolution = Enums.Preview.HD.getValue();
   private YuvToRgbConverter converter;
@@ -57,7 +57,11 @@ public abstract class CameraFragment extends ControlsFragment {
   private View addCamera(View view, LayoutInflater inflater, ViewGroup container) {
     View cameraView = inflater.inflate(R.layout.fragment_camera, container, false);
     ViewGroup rootView = (ViewGroup) cameraView.getRootView();
-
+    // set lensFacing from user preferences (last used setting)
+    lensFacing =
+        preferencesManager.getCameraSwitch()
+            ? CameraSelector.LENS_FACING_FRONT
+            : CameraSelector.LENS_FACING_BACK;
     previewView = cameraView.findViewById(R.id.viewFinder);
     rootView.addView(view);
 
@@ -175,6 +179,7 @@ public abstract class CameraFragment extends ControlsFragment {
         CameraSelector.LENS_FACING_FRONT == lensFacing
             ? CameraSelector.LENS_FACING_BACK
             : CameraSelector.LENS_FACING_FRONT;
+    preferencesManager.setCameraSwitch(!preferencesManager.getCameraSwitch());
     bindCameraUseCases();
   }
 

--- a/android/app/src/main/java/org/openbot/common/ControlsFragment.java
+++ b/android/app/src/main/java/org/openbot/common/ControlsFragment.java
@@ -67,6 +67,13 @@ public abstract class ControlsFragment extends Fragment implements ServerListene
   private Spinner serverSpinner;
 
   @Override
+  public void onCreate(@Nullable Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    // needs to be created befor .inflateFragment() to prevent npe (in .addCamera())
+    preferencesManager = new SharedPreferencesManager(requireContext());
+  }
+
+  @Override
   public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
     super.onViewCreated(view, savedInstanceState);
     requireActivity()
@@ -75,7 +82,6 @@ public abstract class ControlsFragment extends Fragment implements ServerListene
 
     phoneController = PhoneController.getInstance(requireContext());
 
-    preferencesManager = new SharedPreferencesManager(requireContext());
     audioPlayer = new AudioPlayer(requireContext());
     masterList = FileUtils.loadConfigJSONFromAsset(requireActivity());
     serverCommunication = new ServerCommunication(requireContext(), this);

--- a/android/app/src/main/java/org/openbot/common/ControlsFragment.java
+++ b/android/app/src/main/java/org/openbot/common/ControlsFragment.java
@@ -69,7 +69,7 @@ public abstract class ControlsFragment extends Fragment implements ServerListene
   @Override
   public void onCreate(@Nullable Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
-    // needs to be created befor .inflateFragment() to prevent npe (in .addCamera())
+    // create before inflateFragment() to prevent npe when calling addCamera()
     preferencesManager = new SharedPreferencesManager(requireContext());
   }
 

--- a/android/app/src/main/java/org/openbot/env/SharedPreferencesManager.java
+++ b/android/app/src/main/java/org/openbot/env/SharedPreferencesManager.java
@@ -72,6 +72,11 @@ public class SharedPreferencesManager {
     return preferences.getInt(NUM_THREAD, DEFAULT_NUM_THREAD);
   }
 
+  /**
+   * Get selected camera lens facing
+   *
+   * @return true for LENS_FACING_FRONT, false for LENS_FACING_BACK
+   */
   public boolean getCameraSwitch() {
     return preferences.getBoolean(CAMERA_SWITCH, false);
   }

--- a/android/app/src/main/java/org/openbot/original/CameraActivity.java
+++ b/android/app/src/main/java/org/openbot/original/CameraActivity.java
@@ -200,6 +200,8 @@ public abstract class CameraActivity extends AppCompatActivity
     vehicle = OpenBotApplication.vehicle;
 
     phoneController = PhoneController.getInstance(this);
+    // needs to be created befor .setFragment() to prevent npe (in .getCameraUserSelection())
+    preferencesManager = new SharedPreferencesManager(this);
 
     setContentView(R.layout.activity_camera);
     Toolbar toolbar = findViewById(R.id.toolbar);
@@ -211,8 +213,6 @@ public abstract class CameraActivity extends AppCompatActivity
     } else {
       PermissionUtils.requestCameraPermission(this);
     }
-
-    preferencesManager = new SharedPreferencesManager(this);
 
     connectionSwitchCompat = findViewById(R.id.connection_switch);
     threadsTextView = findViewById(R.id.threads);
@@ -851,9 +851,16 @@ public abstract class CameraActivity extends AppCompatActivity
   protected int getCameraUserSelection() {
     // during initialisation there is no cameraToggle so we assume default
     if (this.cameraSwitchCompat == null) {
-      this.cameraSelection = CameraCharacteristics.LENS_FACING_BACK;
+      // set from user preferences (last used selection)
+      this.cameraSelection =
+          preferencesManager.getCameraSwitch()
+              ? CameraCharacteristics.LENS_FACING_FRONT
+              : CameraCharacteristics.LENS_FACING_BACK;
     } else {
-      this.cameraSelection = this.cameraSwitchCompat.isChecked() ? 0 : 1;
+      this.cameraSelection =
+          this.cameraSwitchCompat.isChecked()
+              ? CameraCharacteristics.LENS_FACING_FRONT
+              : CameraCharacteristics.LENS_FACING_BACK;
     }
     return this.cameraSelection;
   }

--- a/android/app/src/main/java/org/openbot/original/CameraActivity.java
+++ b/android/app/src/main/java/org/openbot/original/CameraActivity.java
@@ -200,7 +200,6 @@ public abstract class CameraActivity extends AppCompatActivity
     vehicle = OpenBotApplication.vehicle;
 
     phoneController = PhoneController.getInstance(this);
-    // needs to be created befor .setFragment() to prevent npe (in .getCameraUserSelection())
     preferencesManager = new SharedPreferencesManager(this);
 
     setContentView(R.layout.activity_camera);


### PR DESCRIPTION
updated solution for closed pr https://github.com/isl-org/OpenBot/pull/332 to remember selected camera lens facing between AI screens and app restarts.

with following changes
1. using existing CAMERA_SWITCH setting as init value by all AI bottom sheets
2. let all bottom sheets write back CAMERA_SWITCH changes (as currently DefaultActivity does)