### PR TITLE
Fix speedMode during inference

### DIFF
--- a/android/app/src/main/java/org/openbot/autopilot/AutopilotFragment.java
+++ b/android/app/src/main/java/org/openbot/autopilot/AutopilotFragment.java
@@ -349,13 +349,19 @@ public class AutopilotFragment extends CameraFragment {
     binding.autoSwitch.setChecked(b);
     binding.controllerContainer.controlMode.setEnabled(!b);
     binding.controllerContainer.driveMode.setEnabled(!b);
-    binding.controllerContainer.speedInfo.setEnabled(!b);
+    binding.controllerContainer.speedMode.setEnabled(!b);
 
     binding.controllerContainer.controlMode.setAlpha(b ? 0.5f : 1f);
     binding.controllerContainer.driveMode.setAlpha(b ? 0.5f : 1f);
     binding.controllerContainer.speedMode.setAlpha(b ? 0.5f : 1f);
 
-    if (!b) handler.postDelayed(() -> vehicle.setControl(0, 0), 500);
+    if (!b) {
+      setSpeedMode(Enums.SpeedMode.getByID(preferencesManager.getSpeedMode()));
+      handler.postDelayed(() -> vehicle.setControl(0, 0), 500);
+    } else {
+      binding.controllerContainer.speedMode.setImageResource(R.drawable.ic_speed_high);
+      vehicle.setSpeedMultiplier(Enums.SpeedMode.FAST.getValue());
+    }
   }
 
   private long frameNum = 0;
@@ -459,7 +465,7 @@ public class AutopilotFragment extends CameraFragment {
   }
 
   private void setSpeedMode(Enums.SpeedMode speedMode) {
-    if (speedMode != null) {
+    if (speedMode != null && !binding.autoSwitch.isChecked()) {
       switch (speedMode) {
         case SLOW:
           binding.controllerContainer.speedMode.setImageResource(R.drawable.ic_speed_low);

--- a/android/app/src/main/java/org/openbot/autopilot/AutopilotFragment.java
+++ b/android/app/src/main/java/org/openbot/autopilot/AutopilotFragment.java
@@ -10,6 +10,7 @@ import android.os.Handler;
 import android.os.HandlerThread;
 import android.os.SystemClock;
 import android.util.TypedValue;
+import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -292,6 +293,17 @@ public class AutopilotFragment extends CameraFragment {
             R.string.speedInfo,
             String.format(
                 Locale.US, "%3.0f,%3.0f", vehicle.getLeftWheelRpm(), vehicle.getRightWheelRpm())));
+  }
+
+  @Override
+  protected void processKeyEvent(KeyEvent keyCode) {
+    if (binding.autoSwitch.isChecked()
+        && (keyCode.getKeyCode() == KeyEvent.KEYCODE_BUTTON_THUMBL
+            || keyCode.getKeyCode() == KeyEvent.KEYCODE_BUTTON_THUMBR)) {
+      audioPlayer.playFromString("Autopilot active. Cannot change speed mode.");
+    } else {
+      super.processKeyEvent(keyCode);
+    }
   }
 
   @Override

--- a/android/app/src/main/java/org/openbot/common/ControlsFragment.java
+++ b/android/app/src/main/java/org/openbot/common/ControlsFragment.java
@@ -172,7 +172,7 @@ public abstract class ControlsFragment extends Fragment implements ServerListene
     handlePhoneControllerEvents();
   }
 
-  private void processKeyEvent(KeyEvent keyCode) {
+  protected void processKeyEvent(KeyEvent keyCode) {
     if (Enums.ControlMode.getByID(preferencesManager.getControlMode())
         == Enums.ControlMode.GAMEPAD) {
       switch (keyCode.getKeyCode()) {
@@ -209,6 +209,7 @@ public abstract class ControlsFragment extends Fragment implements ServerListene
           break;
         case KeyEvent.KEYCODE_BUTTON_THUMBR:
           processControllerKeyData(Constants.CMD_SPEED_UP);
+
           audioPlayer.playSpeedMode(
               voice, Enums.SpeedMode.getByID(preferencesManager.getSpeedMode()));
           break;

--- a/android/app/src/main/java/org/openbot/objectNav/ObjectNavFragment.java
+++ b/android/app/src/main/java/org/openbot/objectNav/ObjectNavFragment.java
@@ -388,7 +388,7 @@ public class ObjectNavFragment extends CameraFragment {
 
     binding.controllerContainer.controlMode.setEnabled(!b);
     binding.controllerContainer.driveMode.setEnabled(!b);
-    binding.controllerContainer.speedInfo.setEnabled(!b);
+    binding.controllerContainer.speedMode.setEnabled(!b);
 
     binding.controllerContainer.controlMode.setAlpha(b ? 0.5f : 1f);
     binding.controllerContainer.driveMode.setAlpha(b ? 0.5f : 1f);


### PR DESCRIPTION
In Autopilot/ObjectNav mode:

auto on
- set speedMode to fast (only for autopilot)
- disable speedMode setting

auto off
- restore previously stored speedMode setting (only for autopilot)
- enable speedMode setting