### PR TITLE
Support connection between robot phone and controller phone using one of them as Wifi AP

### DIFF
--- a/android/controller/src/main/java/org/openbot/controller/ConnectionSelector.kt
+++ b/android/controller/src/main/java/org/openbot/controller/ConnectionSelector.kt
@@ -18,7 +18,7 @@ object ConnectionSelector {
     }
 
     fun getConnection(): ILocalConnection {
-        val connected = isConnectedViaWifi(context)
+        val connected = isConnectedViaWifi(context) || isWifiApEnabled(context)
         return if (connected) NetworkServiceConnection else NearbyConnection
     }
 
@@ -29,5 +29,15 @@ object ConnectionSelector {
         val networkId = info.networkId
 
         return networkId > 0
+    }
+
+    private fun isWifiApEnabled(context: Context): Boolean {
+        val wifiManager = context.getSystemService(WIFI_SERVICE) as WifiManager
+        return try {
+            val method = wifiManager.javaClass.getDeclaredMethod("isWifiApEnabled")
+            method.invoke(wifiManager) as? Boolean == true
+        } catch (ignored: Throwable) {
+            false
+        }
     }
 }

--- a/android/controller/src/main/java/org/openbot/controller/customComponents/VideoViewWebRTC.kt
+++ b/android/controller/src/main/java/org/openbot/controller/customComponents/VideoViewWebRTC.kt
@@ -136,8 +136,15 @@ class VideoViewWebRTC @JvmOverloads constructor(
         val initializationOptions = PeerConnectionFactory.InitializationOptions.builder(context)
             .createInitializationOptions()
         PeerConnectionFactory.initialize(initializationOptions)
+
+        val options = PeerConnectionFactory.Options().apply {
+            networkIgnoreMask = 16
+            disableEncryption = false
+            disableNetworkMonitor = true
+        }
         factory = PeerConnectionFactory.builder().setVideoEncoderFactory(encoderFactory)
-            .setVideoDecoderFactory(decoderFactory).createPeerConnectionFactory()
+            .setVideoDecoderFactory(decoderFactory)
+            .setOptions(options).createPeerConnectionFactory()
     }
 
     private fun initializePeerConnections() {

--- a/android/robot/src/main/java/org/openbot/env/ConnectionSelector.java
+++ b/android/robot/src/main/java/org/openbot/env/ConnectionSelector.java
@@ -3,6 +3,9 @@ package org.openbot.env;
 import android.content.Context;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
+import android.net.wifi.WifiManager;
+
+import java.lang.reflect.Method;
 
 public class ConnectionSelector {
   private static final String TAG = "ConnectionManager";
@@ -37,7 +40,7 @@ public class ConnectionSelector {
       return connection;
     }
 
-    if (isConnectedViaWifi()) {
+    if (isConnectedViaWifi() || isWifiApEnabled()) {
       connection = networkConnection;
     } else {
       connection = nearbyConnection;
@@ -51,5 +54,18 @@ public class ConnectionSelector {
         (ConnectivityManager) _context.getSystemService(Context.CONNECTIVITY_SERVICE);
     NetworkInfo mWifi = connectivityManager.getNetworkInfo(ConnectivityManager.TYPE_WIFI);
     return mWifi.isConnected();
+  }
+
+  private boolean isWifiApEnabled() {
+    WifiManager wifiManager =
+            (WifiManager) _context.getSystemService(Context.WIFI_SERVICE);
+    try {
+      final Method method =
+              wifiManager.getClass().getDeclaredMethod("isWifiApEnabled");
+      Boolean result = (Boolean) method.invoke(wifiManager);
+      return Boolean.TRUE.equals(result);
+    } catch (final Throwable ignored) {}
+
+    return false;
   }
 }

--- a/android/robot/src/main/java/org/openbot/env/WebRtcServer.java
+++ b/android/robot/src/main/java/org/openbot/env/WebRtcServer.java
@@ -407,10 +407,16 @@ public class WebRtcServer implements IVideoServer {
         PeerConnectionFactory.InitializationOptions.builder(context).createInitializationOptions();
     PeerConnectionFactory.initialize(initializationOptions);
 
+    PeerConnectionFactory.Options options = new PeerConnectionFactory.Options();
+    options.networkIgnoreMask = 16;
+    options.disableEncryption = false;
+    options.disableNetworkMonitor = true;
+
     factory =
         PeerConnectionFactory.builder()
             .setVideoEncoderFactory(encoderFactory)
             .setVideoDecoderFactory(decoderFactory)
+            .setOptions(options)
             .createPeerConnectionFactory();
   }
 


### PR DESCRIPTION
Currently when using one phone as Wifi AP and the other connect to this AP, controller app and robot app can NOT connect (issue [387](https://github.com/isl-org/OpenBot/issues/387)). This PR should fix it. Fix has been tested and it works.