### PR TITLE
Solved the error when training the model on local Jupyter Notebook

### DIFF
--- a/controller/node-js/README.md
+++ b/controller/node-js/README.md
@@ -84,6 +84,5 @@ None.
 
 ## Things to do/try
 
-* This software has not been tested on Windows. It would be useful if somebody can test and update this documentation.
 * We need to investigate if we can connect to the server remotely, and if WebRTC will still work. We should document firewall configuration to make this possible.
 * We need to create a ```production``` configuration, possibly using [pm2 process manager](https://www.npmjs.com/package/pm2) and [nginx](https://docs.nginx.com/nginx/admin-guide/web-server/reverse-proxy/).

--- a/policy/policy_learning.ipynb
+++ b/policy/policy_learning.ipynb
@@ -291,6 +291,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Create the directory if it doesn't exist\n",
+    "os.makedirs(os.path.join(os.getcwd(), \"models\", tr.model_name), exist_ok=True)\n\n",
     "# params.NUM_EPOCHS = 200\n",
     "# params.USE_LAST = True\n",
     "train.do_training(tr, my_callback, verbose=1)"


### PR DESCRIPTION
The Jupyter Notebook "policy_learning" is unable to create the model training folder. Throwing the FileNotFoundError. Resolved this by adding a line that creates a directory if it does not already exist. 

Notebook Running:
![Screenshot 2024-03-05 135923](https://github.com/isl-org/OpenBot/assets/69849348/bcd42f7f-0fba-4445-a659-19c672acca6f)

Error Encountered:
![Screenshot 2024-03-06 131830](https://github.com/isl-org/OpenBot/assets/69849348/ac1becee-3973-41ac-ab48-a5cfea1d731b)

Error Fixed:
![Screenshot 2024-03-06 131957](https://github.com/isl-org/OpenBot/assets/69849348/6c2d7c36-0041-4723-943f-8fe0f64f6b4f)
