### PR TITLE
Solved error when training the model on OpenBot Driving Policy Trainer

### DIFF
--- a/controller/node-js/README.md
+++ b/controller/node-js/README.md
@@ -84,6 +84,5 @@ None.
 
 ## Things to do/try
 
-* This software has not been tested on Windows. It would be useful if somebody can test and update this documentation.
 * We need to investigate if we can connect to the server remotely, and if WebRTC will still work. We should document firewall configuration to make this possible.
 * We need to create a ```production``` configuration, possibly using [pm2 process manager](https://www.npmjs.com/package/pm2) and [nginx](https://docs.nginx.com/nginx/admin-guide/web-server/reverse-proxy/).

--- a/policy/openbot/train.py
+++ b/policy/openbot/train.py
@@ -433,7 +433,10 @@ def do_training(tr: Training, callback: tf.keras.callbacks.Callback, verbose=0):
             tr.hyperparameters.BATCH_NORM,
             tr.hyperparameters.POLICY,
         )
-        dot_img_file = os.path.join(models_dir, tr.model_name, "model.png")
+        # Define the directory where the model image should be saved (if not already created)
+        model_dir = os.path.join(models_dir, tr.model_name)
+        os.makedirs(model_dir, exist_ok=True)
+        dot_img_file = os.path.join(model_dir, "model.png")
         tf.keras.utils.plot_model(model, to_file=dot_img_file, show_shapes=True)
 
     callback.broadcast("model", tr.model_name)

--- a/policy/policy_learning.ipynb
+++ b/policy/policy_learning.ipynb
@@ -291,6 +291,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Create the directory if it doesn't exist\n",
+    "os.makedirs(os.path.join(os.getcwd(), \"models\", tr.model_name), exist_ok=True)\n\n",
     "# params.NUM_EPOCHS = 200\n",
     "# params.USE_LAST = True\n",
     "train.do_training(tr, my_callback, verbose=1)"


### PR DESCRIPTION
The local Conda environment is unable to proceed with the model training process. Solved this by updating the code in train.py file within the do_training function.

The Error Encountered:
![Screenshot 2024-03-05 103805](https://github.com/isl-org/OpenBot/assets/69849348/362c4848-55d7-4a91-a570-4b7dd85d99b1)

Error Log file:
[log.txt](https://github.com/isl-org/OpenBot/files/14554573/log.txt)

Error Encountered (logging session):
![Screenshot 2024-03-05 105732](https://github.com/isl-org/OpenBot/assets/69849348/1582267f-39ec-48d6-873f-ed9f29913dda)

OpenBot Driving Policy Trainer (Datasets):
![Screenshot 2024-03-05 103935](https://github.com/isl-org/OpenBot/assets/69849348/7d8f52b9-8fc1-41f1-92ed-40e9777e55a9)

OpenBot Driving Policy Trainer (Train):
![Screenshot 2024-03-05 104257](https://github.com/isl-org/OpenBot/assets/69849348/0f9ffbae-1bf9-40c0-b4e2-b50418727ecd)

Solved log file:
[resolve_log.txt](https://github.com/isl-org/OpenBot/files/14555210/resolve_log.txt)