### PR TITLE
Unify the driveMode storage and fetching - from ControlsFragment.vehicle.driveMode, instead of ControlsFragment.currentDriveMode.

### DIFF
--- a/android/robot/src/main/java/org/openbot/autopilot/AutopilotFragment.java
+++ b/android/robot/src/main/java/org/openbot/autopilot/AutopilotFragment.java
@@ -459,7 +459,7 @@ public class AutopilotFragment extends CameraFragment {
 
     private void connectWebController() {
         phoneController.connectWebServer();
-        Enums.DriveMode oldDriveMode = currentDriveMode;
+        Enums.DriveMode oldDriveMode = vehicle.getDriveMode();
         // Currently only dual drive mode supported
         setDriveMode(Enums.DriveMode.GAME);
         binding.controllerContainer.driveMode.setAlpha(0.5f);
@@ -575,7 +575,7 @@ public class AutopilotFragment extends CameraFragment {
 
     private void connectPhoneController() {
         phoneController.connect(requireContext());
-        Enums.DriveMode oldDriveMode = currentDriveMode;
+        Enums.DriveMode oldDriveMode = vehicle.getDriveMode();
         // Currently only dual drive mode supported
         setDriveMode(Enums.DriveMode.DUAL);
         binding.controllerContainer.driveMode.setAlpha(0.5f);

--- a/android/robot/src/main/java/org/openbot/common/ControlsFragment.java
+++ b/android/robot/src/main/java/org/openbot/common/ControlsFragment.java
@@ -52,8 +52,6 @@ public abstract class ControlsFragment extends Fragment implements ServerListene
   protected Animation startAnimation;
   protected SharedPreferencesManager preferencesManager;
   protected PhoneController phoneController;
-  protected Enums.DriveMode currentDriveMode = Enums.DriveMode.GAME;
-
   protected AudioPlayer audioPlayer;
 
   protected final String voice = "matthew";
@@ -282,7 +280,7 @@ public abstract class ControlsFragment extends Fragment implements ServerListene
               // That is why we are not calling phoneController.send() here directly.
               BotToControllerEventBus.emitEvent(
                   ConnectionUtils.getStatus(
-                      false, false, false, currentDriveMode.toString(), vehicle.getIndicator()));
+                      false, false, false, vehicle.getDriveMode().toString(), vehicle.getIndicator()));
               break;
 
             case Constants.CMD_DISCONNECTED:

--- a/android/robot/src/main/java/org/openbot/logging/LoggerFragment.java
+++ b/android/robot/src/main/java/org/openbot/logging/LoggerFragment.java
@@ -585,7 +585,7 @@ public class LoggerFragment extends CameraFragment {
 
   private void connectPhoneController() {
     phoneController.connect(requireContext());
-    Enums.DriveMode oldDriveMode = currentDriveMode;
+    Enums.DriveMode oldDriveMode = vehicle.getDriveMode();
     // Currently only dual drive mode supported
     setDriveMode(Enums.DriveMode.DUAL);
     binding.controllerContainer.driveMode.setAlpha(0.5f);
@@ -595,7 +595,7 @@ public class LoggerFragment extends CameraFragment {
 
   private void connectWebController() {
     phoneController.connectWebServer();
-    Enums.DriveMode oldDriveMode = currentDriveMode;
+    Enums.DriveMode oldDriveMode = vehicle.getDriveMode();
     // Currently only dual drive mode supported
     setDriveMode(Enums.DriveMode.GAME);
     binding.controllerContainer.driveMode.setAlpha(0.5f);

--- a/android/robot/src/main/java/org/openbot/objectNav/ObjectNavFragment.java
+++ b/android/robot/src/main/java/org/openbot/objectNav/ObjectNavFragment.java
@@ -654,7 +654,7 @@ public class ObjectNavFragment extends CameraFragment {
 
   private void connectPhoneController() {
     phoneController.connect(requireContext());
-    Enums.DriveMode oldDriveMode = currentDriveMode;
+    Enums.DriveMode oldDriveMode = vehicle.getDriveMode();
     // Currently only dual drive mode supported
     setDriveMode(Enums.DriveMode.DUAL);
     binding.controllerContainer.driveMode.setAlpha(0.5f);
@@ -664,7 +664,7 @@ public class ObjectNavFragment extends CameraFragment {
 
   private void connectWebController() {
     phoneController.connectWebServer();
-    Enums.DriveMode oldDriveMode = currentDriveMode;
+    Enums.DriveMode oldDriveMode = vehicle.getDriveMode();
     // Currently only dual drive mode supported
     setDriveMode(Enums.DriveMode.GAME);
     binding.controllerContainer.driveMode.setAlpha(0.5f);

--- a/android/robot/src/main/java/org/openbot/robot/FreeRoamFragment.java
+++ b/android/robot/src/main/java/org/openbot/robot/FreeRoamFragment.java
@@ -272,9 +272,9 @@ public class FreeRoamFragment extends ControlsFragment {
 
   private void connectWebController() {
     phoneController.connectWebServer();
-    Enums.DriveMode oldDriveMode = vehicle.getDriveMode();
+    DriveMode oldDriveMode = vehicle.getDriveMode();
     // Currently only dual drive mode supported
-    setDriveMode(Enums.DriveMode.GAME);
+    setDriveMode(DriveMode.GAME);
     binding.controllerContainer.driveMode.setAlpha(0.5f);
     binding.controllerContainer.driveMode.setEnabled(false);
     preferencesManager.setDriveMode(oldDriveMode.getValue());

--- a/android/robot/src/main/java/org/openbot/robot/FreeRoamFragment.java
+++ b/android/robot/src/main/java/org/openbot/robot/FreeRoamFragment.java
@@ -262,7 +262,7 @@ public class FreeRoamFragment extends ControlsFragment {
 
   private void connectPhoneController() {
     phoneController.connect(requireContext());
-    DriveMode oldDriveMode = currentDriveMode;
+    DriveMode oldDriveMode = vehicle.getDriveMode();
     // Currently only dual drive mode supported
     setDriveMode(DriveMode.DUAL);
     binding.controllerContainer.driveMode.setAlpha(0.5f);
@@ -272,7 +272,7 @@ public class FreeRoamFragment extends ControlsFragment {
 
   private void connectWebController() {
     phoneController.connectWebServer();
-    Enums.DriveMode oldDriveMode = currentDriveMode;
+    Enums.DriveMode oldDriveMode = vehicle.getDriveMode();
     // Currently only dual drive mode supported
     setDriveMode(Enums.DriveMode.GAME);
     binding.controllerContainer.driveMode.setAlpha(0.5f);


### PR DESCRIPTION
Unify the driveMode storage and fetching - from ControlsFragment.vehicle.driveMode, instead of ControlsFragment.currentDriveMode.

There are two places containing drive mode: ControlsFragment.currentDriveMode, and ControlsFragment.vehicle.driveMode. They should be unified. ControlsFragment.vehicle.driveMode is used more widely(as shown below) and is supposed to be the final one.

![image](https://github.com/user-attachments/assets/6c7aa83e-6c90-4d5a-8d92-d4b2f00aa895)
