### PR TITLE
fix(policy): force legacy Keras for TF >= 2.16 compatibility

### DIFF
--- a/policy/openbot/__init__.py
+++ b/policy/openbot/__init__.py
@@ -1,5 +1,11 @@
 import os
 
+# Force the legacy Keras (Keras 2) backend so this code, which targets the
+# Keras 2 model API, also works on TensorFlow >= 2.16 (which switched to Keras 3
+# by default and would otherwise raise "the layer ... has never been called"
+# during model building). Must be set before TensorFlow is imported.
+os.environ.setdefault("TF_USE_LEGACY_KERAS", "1")
+
 
 def mkdir(path):
     if not (os.path.exists(path)):


### PR DESCRIPTION
## Summary

TF 2.16 switched the default Keras to Keras 3, which breaks the existing Keras 2 model definitions in `policy/openbot/models.py` with `the layer ... has never been called and thus has no defined output` for users who deviate from the pinned 2.9.x environment.

Setting `TF_USE_LEGACY_KERAS=1` in `policy/openbot/__init__.py` (which runs before any submodule imports tensorflow) restores Keras 2 behavior, so policy training works on newer TF versions without forcing users to downgrade.

Fixes #447. Workaround originally identified by @sparta-2024 in that issue thread.

## Test plan

- [ ] Train a policy on TF 2.9 (the pinned version) and confirm no behavior change.
- [ ] Train a policy on TF 2.16 / 2.17 and confirm the MLP error no longer occurs.