### PR TITLE
IOS - App language support with flag icons and Settings redesign

### DIFF
--- a/ios/OpenBot/OpenBot.xcodeproj/project.pbxproj
+++ b/ios/OpenBot/OpenBot.xcodeproj/project.pbxproj
@@ -7,9 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0132784A30CAD8239CA1F112 /* en.lproj in Resources */ = {isa = PBXBuildFile; fileRef = 5022662904BF68D64CED43E6 /* en.lproj */; };
 		0619EECA2C24208B0050EB6A /* Modes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0619EEC92C24208B0050EB6A /* Modes.swift */; };
 		06B219AD2ABD4D6100E65CEF /* SharedPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06B219AC2ABD4D6100E65CEF /* SharedPreferences.swift */; };
 		06C87ABB2B3568E700454299 /* FragmentType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06C87ABA2B3568E700454299 /* FragmentType.swift */; };
+		0FC1E29C290DD4CFD6661E92 /* LanguagePickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6D876AB60453F7E405CAED2 /* LanguagePickerViewController.swift */; };
 		113A1E4E0F1483D107D53843 /* BlockyTasksStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 113A10896533873FE2926AF5 /* BlockyTasksStorage.swift */; };
 		202ADFEAAAEDF465B47E680C /* Pods_OpenBot_OpenBotUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 33E6B08B2CB917BF3DADC757 /* Pods_OpenBot_OpenBotUITests.framework */; };
 		3A3C9E0D29E803AC008758C9 /* projectCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 3A3C9E0C29E803AC008758C9 /* projectCollectionViewCell.xib */; };
@@ -17,6 +19,8 @@
 		3A8EF46C2A6FD0FD00F60B3D /* Starscream in Frameworks */ = {isa = PBXBuildFile; productRef = 3A8EF46B2A6FD0FD00F60B3D /* Starscream */; };
 		3A8EF46F2A6FE22F00F60B3D /* SocketIO in Frameworks */ = {isa = PBXBuildFile; productRef = 3A8EF46E2A6FE22F00F60B3D /* SocketIO */; };
 		3AA7193929DD42CF00DE8336 /* openCode.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3AA7193829DD42CF00DE8336 /* openCode.storyboard */; };
+		4794ACBDCA29E3CDD282D7D7 /* es.lproj in Resources */ = {isa = PBXBuildFile; fileRef = 3544D21BE0D6FC80B9130D6C /* es.lproj */; };
+		4D0CB1162AED2754BD84D5EC /* de.lproj in Resources */ = {isa = PBXBuildFile; fileRef = 5802E8D0A5932C5A8EE202D1 /* de.lproj */; };
 		4FEF40039118AB286DD8CB0C /* DetectorDefault.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FEF47209A4C03D66945462E /* DetectorDefault.swift */; };
 		4FEF403935216C3C68714E27 /* UIViewExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FEF47C56474B6324A408225 /* UIViewExtension.swift */; };
 		4FEF41E8F6D7496059371C24 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4FEF4BBD0A2E51DD7BAD32C5 /* Assets.xcassets */; };
@@ -49,6 +53,7 @@
 		4FEF4DC031698B6DEEB01AEB /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FEF4620693FBFF8ABFC0350 /* AppDelegate.swift */; };
 		4FEF4E9F41A93B4F6CD1AEEC /* DetectorFloatYoloV4.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FEF4633FC7402D71728D03F /* DetectorFloatYoloV4.swift */; };
 		4FEF4F78919CCCC28C418C5B /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FEF4D63E4FA9FB585EF1733 /* SceneDelegate.swift */; };
+		625648814110B723B1E20904 /* LocalizationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3851548982D6168C4AE03B23 /* LocalizationManager.swift */; };
 		660FACB729BFEDE000223373 /* MTLDevice+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 660FACAF29BFEDE000223373 /* MTLDevice+.swift */; };
 		660FACB829BFEDE000223373 /* CVReturnError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 660FACB029BFEDE000223373 /* CVReturnError.swift */; };
 		660FACB929BFEDE000223373 /* CVPixelBuffer+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 660FACB129BFEDE000223373 /* CVPixelBuffer+.swift */; };
@@ -134,7 +139,13 @@
 		727D3F785C662A5A6C00D835 /* SocketManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 727D3A67A02F3F30135DFA43 /* SocketManager.swift */; };
 		727D3FA70675D0042BFBB89A /* ScannerFragment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 727D3E372C09E1BADA2A03FA /* ScannerFragment.swift */; };
 		7AAD390ED6FC7AE7006497C2 /* Pods_OpenBot.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7061589D8480D4960FF75E85 /* Pods_OpenBot.framework */; };
+		9DF2B487D2E84C13EEC5DA49 /* L10n.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2C14C13C32837A657E727DE /* L10n.swift */; };
 		BF9BAED828AF94A800EF3E48 /* GameController.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BF9BAED728AF94A800EF3E48 /* GameController.framework */; };
+		C3CCC7125418B1718A485429 /* hi.lproj in Resources */ = {isa = PBXBuildFile; fileRef = 04AF5D31F658D5CC10BFA475 /* hi.lproj */; };
+		C7C5AF4374229CEA7D31D489 /* ko.lproj in Resources */ = {isa = PBXBuildFile; fileRef = 68C567D4A10DB39305F83C5E /* ko.lproj */; };
+		D05873148B42EC94B04CA2D7 /* fr.lproj in Resources */ = {isa = PBXBuildFile; fileRef = 3BB0877EC1CEBF363E89AC40 /* fr.lproj */; };
+		DE140ADB3A5AD0CB5887236E /* zh-Hans.lproj in Resources */ = {isa = PBXBuildFile; fileRef = FEF69C473286A88068044136 /* zh-Hans.lproj */; };
+		E72DD15800419B5599A50187 /* LanguageApplyingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C349227CFEDFA7E55F8ACB73 /* LanguageApplyingView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -155,6 +166,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		04AF5D31F658D5CC10BFA475 /* hi.lproj */ = {isa = PBXFileReference; explicitFileType = folder; includeInIndex = 1; path = hi.lproj; sourceTree = "<group>"; };
 		0619EEC92C24208B0050EB6A /* Modes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Modes.swift; path = OpenBot/Models/Modes.swift; sourceTree = SOURCE_ROOT; };
 		06318656CBC7BD5A24BCD958 /* Pods-OpenBotTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OpenBotTests.release.xcconfig"; path = "Target Support Files/Pods-OpenBotTests/Pods-OpenBotTests.release.xcconfig"; sourceTree = "<group>"; };
 		06B219AC2ABD4D6100E65CEF /* SharedPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedPreferences.swift; sourceTree = "<group>"; };
@@ -162,9 +174,12 @@
 		098B4AF0C5ADA51553414CE8 /* Pods-OpenBot-OpenBotUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OpenBot-OpenBotUITests.debug.xcconfig"; path = "Target Support Files/Pods-OpenBot-OpenBotUITests/Pods-OpenBot-OpenBotUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		113A10896533873FE2926AF5 /* BlockyTasksStorage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlockyTasksStorage.swift; sourceTree = "<group>"; };
 		33E6B08B2CB917BF3DADC757 /* Pods_OpenBot_OpenBotUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_OpenBot_OpenBotUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		3544D21BE0D6FC80B9130D6C /* es.lproj */ = {isa = PBXFileReference; explicitFileType = folder; includeInIndex = 1; path = es.lproj; sourceTree = "<group>"; };
+		3851548982D6168C4AE03B23 /* LocalizationManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LocalizationManager.swift; sourceTree = "<group>"; };
 		3A3C9E0C29E803AC008758C9 /* projectCollectionViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = projectCollectionViewCell.xib; sourceTree = "<group>"; };
 		3A70CA1129C98E5800E4192B /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		3AA7193829DD42CF00DE8336 /* openCode.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = openCode.storyboard; sourceTree = "<group>"; };
+		3BB0877EC1CEBF363E89AC40 /* fr.lproj */ = {isa = PBXFileReference; explicitFileType = folder; includeInIndex = 1; path = fr.lproj; sourceTree = "<group>"; };
 		3FDBC2A41BB7D226A4447AD8 /* Pods-OpenBot-OpenBotUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OpenBot-OpenBotUITests.release.xcconfig"; path = "Target Support Files/Pods-OpenBot-OpenBotUITests/Pods-OpenBot-OpenBotUITests.release.xcconfig"; sourceTree = "<group>"; };
 		4FEF4178D0A2805591A6A3A6 /* Strings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Strings.swift; sourceTree = "<group>"; };
 		4FEF41FCA3B501192D417D73 /* CVPixelBuffer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CVPixelBuffer.swift; path = extensions/CVPixelBuffer.swift; sourceTree = "<group>"; };
@@ -202,6 +217,8 @@
 		4FEF4E5F632AD6ADE2049FB8 /* UIImage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UIImage.swift; path = extensions/UIImage.swift; sourceTree = "<group>"; };
 		4FEF4EE1E197D3F52EFF3B88 /* Launch Screen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = "Launch Screen.storyboard"; sourceTree = "<group>"; };
 		4FEF4F7AB94F76161A467A24 /* Notifications.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Notifications.swift; path = extensions/Notifications.swift; sourceTree = "<group>"; };
+		5022662904BF68D64CED43E6 /* en.lproj */ = {isa = PBXFileReference; explicitFileType = folder; includeInIndex = 1; path = en.lproj; sourceTree = "<group>"; };
+		5802E8D0A5932C5A8EE202D1 /* de.lproj */ = {isa = PBXFileReference; explicitFileType = folder; includeInIndex = 1; path = de.lproj; sourceTree = "<group>"; };
 		660FACAF29BFEDE000223373 /* MTLDevice+.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "MTLDevice+.swift"; sourceTree = "<group>"; };
 		660FACB029BFEDE000223373 /* CVReturnError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CVReturnError.swift; sourceTree = "<group>"; };
 		660FACB129BFEDE000223373 /* CVPixelBuffer+.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CVPixelBuffer+.swift"; sourceTree = "<group>"; };
@@ -233,6 +250,7 @@
 		66AC721829B885C70022108A /* Navigation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Navigation.swift; sourceTree = "<group>"; };
 		66B3C59B2A1D673D0079BC16 /* UIButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIButton.swift; sourceTree = "<group>"; };
 		66E7A02B297697BE00283ED6 /* DetectorFloatYoloV5.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DetectorFloatYoloV5.swift; sourceTree = "<group>"; };
+		68C567D4A10DB39305F83C5E /* ko.lproj */ = {isa = PBXFileReference; explicitFileType = folder; includeInIndex = 1; path = ko.lproj; sourceTree = "<group>"; };
 		6D8F8740E0AB9219D371A47C /* Pods_OpenBotTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_OpenBotTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7061589D8480D4960FF75E85 /* Pods_OpenBot.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_OpenBot.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		727D300DE421E6957CB4CD67 /* Readme.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = Readme.md; sourceTree = "<group>"; };
@@ -290,7 +308,11 @@
 		B0C497FCA3C570745DDC0A3D /* Pods-OpenBot.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OpenBot.release.xcconfig"; path = "Target Support Files/Pods-OpenBot/Pods-OpenBot.release.xcconfig"; sourceTree = "<group>"; };
 		BB8946D47143268197073454 /* Pods-OpenBotTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OpenBotTests.debug.xcconfig"; path = "Target Support Files/Pods-OpenBotTests/Pods-OpenBotTests.debug.xcconfig"; sourceTree = "<group>"; };
 		BF9BAED728AF94A800EF3E48 /* GameController.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GameController.framework; path = System/Library/Frameworks/GameController.framework; sourceTree = SDKROOT; };
+		C349227CFEDFA7E55F8ACB73 /* LanguageApplyingView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LanguageApplyingView.swift; sourceTree = "<group>"; };
+		E2C14C13C32837A657E727DE /* L10n.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = L10n.swift; sourceTree = "<group>"; };
+		F6D876AB60453F7E405CAED2 /* LanguagePickerViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LanguagePickerViewController.swift; sourceTree = "<group>"; };
 		FA864C211FDA0FFF7C141891 /* Pods-OpenBot.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OpenBot.debug.xcconfig"; path = "Target Support Files/Pods-OpenBot/Pods-OpenBot.debug.xcconfig"; sourceTree = "<group>"; };
+		FEF69C473286A88068044136 /* zh-Hans.lproj */ = {isa = PBXFileReference; explicitFileType = folder; includeInIndex = 1; path = "zh-Hans.lproj"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -382,6 +404,8 @@
 				727D3E5643531AC215E4101B /* UIButton.swift */,
 				727D383824EABABFDE0806CE /* Toast.swift */,
 				727D38DAC31CD27C5DE891F4 /* Reachability.swift */,
+				E2C14C13C32837A657E727DE /* L10n.swift */,
+				3851548982D6168C4AE03B23 /* LocalizationManager.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -418,6 +442,13 @@
 				727D3BBE14B8FA7877902A13 /* Authentication */,
 				727D317DC854B57A8D176DA7 /* JsEvaluator */,
 				727D3004C935D2676EA98064 /* Projects */,
+				5022662904BF68D64CED43E6 /* en.lproj */,
+				5802E8D0A5932C5A8EE202D1 /* de.lproj */,
+				3544D21BE0D6FC80B9130D6C /* es.lproj */,
+				3BB0877EC1CEBF363E89AC40 /* fr.lproj */,
+				FEF69C473286A88068044136 /* zh-Hans.lproj */,
+				68C567D4A10DB39305F83C5E /* ko.lproj */,
+				04AF5D31F658D5CC10BFA475 /* hi.lproj */,
 			);
 			path = OpenBot;
 			sourceTree = "<group>";
@@ -562,6 +593,8 @@
 			isa = PBXGroup;
 			children = (
 				66AC71E329B885410022108A /* SettingsFragment.swift */,
+				C349227CFEDFA7E55F8ACB73 /* LanguageApplyingView.swift */,
+				F6D876AB60453F7E405CAED2 /* LanguagePickerViewController.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -936,6 +969,13 @@
 				3AA7193929DD42CF00DE8336 /* openCode.storyboard in Resources */,
 				4FEF4209E4568C06F71C8E86 /* config.json in Resources */,
 				3A70CA1229C98E5800E4192B /* GoogleService-Info.plist in Resources */,
+				0132784A30CAD8239CA1F112 /* en.lproj in Resources */,
+				4D0CB1162AED2754BD84D5EC /* de.lproj in Resources */,
+				4794ACBDCA29E3CDD282D7D7 /* es.lproj in Resources */,
+				D05873148B42EC94B04CA2D7 /* fr.lproj in Resources */,
+				DE140ADB3A5AD0CB5887236E /* zh-Hans.lproj in Resources */,
+				C7C5AF4374229CEA7D31D489 /* ko.lproj in Resources */,
+				C3CCC7125418B1718A485429 /* hi.lproj in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1359,6 +1399,10 @@
 				727D3A6C79B27AE7C7AF4FB3 /* WebSocketConnection.swift in Sources */,
 				727D3C40C6A407C68234FEE8 /* WebSocketProvider.swift in Sources */,
 				727D3595B21D2EC9BDAEDF5C /* ServerSignalingMessage.swift in Sources */,
+				9DF2B487D2E84C13EEC5DA49 /* L10n.swift in Sources */,
+				625648814110B723B1E20904 /* LocalizationManager.swift in Sources */,
+				E72DD15800419B5599A50187 /* LanguageApplyingView.swift in Sources */,
+				0FC1E29C290DD4CFD6661E92 /* LanguagePickerViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/OpenBot/OpenBot/Controllers/Alert/AlertFragment.swift
+++ b/ios/OpenBot/OpenBot/Controllers/Alert/AlertFragment.swift
@@ -10,10 +10,17 @@ import GoogleSignIn
  */
 class alertFragment : UIViewController {
     @IBOutlet weak var confirmLogoutLabel: UILabel!
+    @IBOutlet weak var confirmLogoutMessageLabel: UILabel!
+    @IBOutlet weak var cancelButton: UIButton!
+    @IBOutlet weak var logOutButton: UIButton!
     override func viewDidLoad() {
         super.viewDidLoad();
         view.backgroundColor = UIColor.black.withAlphaComponent(0.6);
         confirmLogoutLabel.font = HelveticaNeue.regular(size: 16);
+        confirmLogoutLabel.text = Strings.confirmLogoutTitle
+        confirmLogoutMessageLabel.text = Strings.confirmLogoutMessage
+        cancelButton.configuration?.title = Strings.canceled
+        logOutButton.configuration?.title = Strings.logOut
     }
     
     @IBAction func cancelBtn(_ sender: Any) {

--- a/ios/OpenBot/OpenBot/Controllers/Autopilot/ExpandedAutoPilot.swift
+++ b/ios/OpenBot/OpenBot/Controllers/Autopilot/ExpandedAutoPilot.swift
@@ -10,7 +10,9 @@ class expandedAutoPilot: UIView {
     let autoModeButton = UISwitch()
     var autoModeLabel = UILabel()
     var serverLabel = UILabel()
+    var speedTitleLabel = UILabel()
     var speedLabel = UILabel()
+    var inputTitleLabel = UILabel()
     var leftSpeedLabel = UILabel()
     var deviceDropDown = DropDown()
     var deviceDropDownLabel = UILabel()
@@ -47,14 +49,29 @@ class expandedAutoPilot: UIView {
         createSwitchButton()
         addSubview(createLabel(text: Strings.server, leadingAnchor: Int(adapted(dimensionSize: 20, to: .height)), topAnchor: Int(adapted(dimensionSize: 50, to: .height))))
         addSubview(createLabel(text: Strings.model, leadingAnchor: Int(adapted(dimensionSize: 20, to: .height)), topAnchor: Int(adapted(dimensionSize: 90, to: .height))))
-        addSubview(createLabel(text: Strings.speed, leadingAnchor: Int(adapted(dimensionSize: 20, to: .height)), topAnchor: Int(adapted(dimensionSize: 120, to: .height))))
+        speedTitleLabel = createLabel(text: Strings.speed, leadingAnchor: Int(adapted(dimensionSize: 20, to: .height)), topAnchor: Int(adapted(dimensionSize: 120, to: .height)))
+        speedTitleLabel.numberOfLines = 1
+        speedTitleLabel.adjustsFontSizeToFitWidth = true
+        speedTitleLabel.minimumScaleFactor = 0.5
+        speedTitleLabel.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(speedTitleLabel)
+        speedTitleLabel.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: adapted(dimensionSize: 20, to: .height)).isActive = true
+        speedTitleLabel.topAnchor.constraint(equalTo: topAnchor, constant: adapted(dimensionSize: 120, to: .height)).isActive = true
+        speedTitleLabel.widthAnchor.constraint(lessThanOrEqualToConstant: 100).isActive = true
         setupSpeed()
         addSubview(createLabel(text: Strings.device, leadingAnchor: Int(adapted(dimensionSize: 20, to: .height)), topAnchor: Int(adapted(dimensionSize: 160, to: .height))))
         createDeviceDropDown()
         createServerDropDown()
         serverDropDown.hide()
         createModelDropDown()
-        addSubview(createLabel(text: Strings.input, leadingAnchor: 180, topAnchor: Int(adapted(dimensionSize: 120, to: .height))))
+        inputTitleLabel = createLabel(text: Strings.input, leadingAnchor: 180, topAnchor: Int(adapted(dimensionSize: 120, to: .height)))
+        inputTitleLabel.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(inputTitleLabel)
+        inputTitleLabel.leadingAnchor.constraint(greaterThanOrEqualTo: speedLabel.trailingAnchor, constant: 12).isActive = true
+        let preferredInputPosition = inputTitleLabel.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: 180)
+        preferredInputPosition.priority = .defaultLow
+        preferredInputPosition.isActive = true
+        inputTitleLabel.topAnchor.constraint(equalTo: topAnchor, constant: adapted(dimensionSize: 120, to: .height)).isActive = true
         setupInput();
         addSubview(createLabel(text: Strings.threads, leadingAnchor: 180, topAnchor: Int(adapted(dimensionSize: 160, to: .height))))
         setupThreads();
@@ -302,15 +319,27 @@ class expandedAutoPilot: UIView {
 
     /// function to create input label frame of model
     func setupInput() {
-        imageInputLabel.frame = CGRect(x: width - 80, y: adapted(dimensionSize: 120, to: .height), width: 100, height: 40)
         imageInputLabel.text = "256x96";
+        imageInputLabel.textColor = Colors.border
+        imageInputLabel.translatesAutoresizingMaskIntoConstraints = false
         addSubview(imageInputLabel)
+        imageInputLabel.leadingAnchor.constraint(greaterThanOrEqualTo: inputTitleLabel.trailingAnchor, constant: 12).isActive = true
+        let preferredImageInputPosition = imageInputLabel.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: width - 80)
+        preferredImageInputPosition.priority = .defaultLow
+        preferredImageInputPosition.isActive = true
+        imageInputLabel.topAnchor.constraint(equalTo: topAnchor, constant: adapted(dimensionSize: 120, to: .height)).isActive = true
     }
 
     /// function to create the ui of speed
     func setupSpeed() {
         speedLabel = createLabel(text: "*** fps", leadingAnchor: 90, topAnchor: Int(adapted(dimensionSize: 120, to: .height)))
+        speedLabel.translatesAutoresizingMaskIntoConstraints = false
         addSubview(speedLabel)
+        speedLabel.leadingAnchor.constraint(greaterThanOrEqualTo: speedTitleLabel.trailingAnchor, constant: 12).isActive = true
+        let preferredPosition = speedLabel.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: 90)
+        preferredPosition.priority = .defaultLow
+        preferredPosition.isActive = true
+        speedLabel.topAnchor.constraint(equalTo: topAnchor, constant: adapted(dimensionSize: 120, to: .height)).isActive = true
     }
 
     /// Create a dropdown list

--- a/ios/OpenBot/OpenBot/Controllers/Autopilot/ExpandedAutoPilot.swift
+++ b/ios/OpenBot/OpenBot/Controllers/Autopilot/ExpandedAutoPilot.swift
@@ -230,7 +230,7 @@ class expandedAutoPilot: UIView {
         serverDropDown.anchorView = serverDropDownView
         serverDropDown.dataSource = servers
         serverDropDown.show()
-        ddView = createDropdownView(borderColor: "", buttonName: "No Server", leadingAnchor: 180, topAnchor: adapted(dimensionSize: 50, to: .height), action: #selector(showServerDropdown(_:)))
+        ddView = createDropdownView(borderColor: "", buttonName: Strings.noServer, leadingAnchor: 180, topAnchor: adapted(dimensionSize: 50, to: .height), action: #selector(showServerDropdown(_:)))
         serverDropDown.selectionAction = { [unowned self] (index: Int, item: String) in
             serverDropDownLabel.text = item
             let server = serverItems.filter { server in
@@ -256,7 +256,7 @@ class expandedAutoPilot: UIView {
         upwardImage.translatesAutoresizingMaskIntoConstraints = false
         upwardImage.trailingAnchor.constraint(equalTo: ddView.trailingAnchor, constant: -10).isActive = true
         upwardImage.topAnchor.constraint(equalTo: ddView.topAnchor, constant: 11.5).isActive = true
-        serverDropDownLabel.text = "No Server"
+        serverDropDownLabel.text = Strings.noServer
         serverDropDownLabel.textColor = Colors.border
         serverDropDownLabel.frame = CGRect(x: 10, y: 0, width: 210, height: 40)
         ddView.addSubview(serverDropDownLabel)

--- a/ios/OpenBot/OpenBot/Controllers/Autopilot/ExpandedAutoPilot.swift
+++ b/ios/OpenBot/OpenBot/Controllers/Autopilot/ExpandedAutoPilot.swift
@@ -186,7 +186,7 @@ class expandedAutoPilot: UIView {
         label.text = text
         label.textColor = Colors.border
         label.frame.origin = CGPoint(x: leadingAnchor, y: topAnchor)
-        label.frame.size = resized(size: CGSize(width: text.count * 10, height: 40), basedOn: .height)
+        label.frame.size = resized(size: CGSize(width: measuredWidth(of: text, font: label.font) + 8, height: 40), basedOn: .height)
         return label
     }
 

--- a/ios/OpenBot/OpenBot/Controllers/Autopilot/ExpandedAutoPilot.swift
+++ b/ios/OpenBot/OpenBot/Controllers/Autopilot/ExpandedAutoPilot.swift
@@ -8,6 +8,7 @@ import DropDown
 
 class expandedAutoPilot: UIView {
     let autoModeButton = UISwitch()
+    var autoModeLabel = UILabel()
     var serverLabel = UILabel()
     var speedLabel = UILabel()
     var leftSpeedLabel = UILabel()
@@ -39,7 +40,8 @@ class expandedAutoPilot: UIView {
         swipeUp.direction = .up
         addGestureRecognizer(swipeUp)
         createBar()
-        addSubview(createLabel(text: Strings.autoMode, leadingAnchor: Int(adapted(dimensionSize: 20, to: .height)), topAnchor: Int(adapted(dimensionSize: 15, to: .height))));
+        autoModeLabel = createLabel(text: Strings.autoMode, leadingAnchor: Int(adapted(dimensionSize: 20, to: .height)), topAnchor: Int(adapted(dimensionSize: 15, to: .height)));
+        addSubview(autoModeLabel);
         createBluetoothIcon()
         createCameraIcon()
         createSwitchButton()
@@ -218,7 +220,10 @@ class expandedAutoPilot: UIView {
         autoModeButton.translatesAutoresizingMaskIntoConstraints = false
         addSubview(autoModeButton)
         autoModeButton.widthAnchor.constraint(equalToConstant: 40).isActive = true
-        autoModeButton.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: 120).isActive = true
+        autoModeButton.leadingAnchor.constraint(greaterThanOrEqualTo: autoModeLabel.trailingAnchor, constant: 12).isActive = true
+        let preferredPosition = autoModeButton.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: 120)
+        preferredPosition.priority = .defaultLow
+        preferredPosition.isActive = true
         autoModeButton.topAnchor.constraint(equalTo: topAnchor, constant: 25).isActive = true
     }
 

--- a/ios/OpenBot/OpenBot/Controllers/CameraController.swift
+++ b/ios/OpenBot/OpenBot/Controllers/CameraController.swift
@@ -291,13 +291,22 @@ class CameraController: UIViewController, AVCaptureVideoDataOutputSampleBufferDe
 
     /// Configure the video(camera output) rotation when screen orientation changes.
     private func configureVideoOrientation() {
-        let orientation = UIDevice.current.orientation
-        if let previewLayer = videoPreviewLayer, let previewConnection = videoPreviewLayer.connection {
-            if previewConnection.isVideoOrientationSupported, let previewOrientation = AVCaptureVideoOrientation(rawValue: orientation.rawValue) {
-                previewLayer.frame = view.bounds
-                previewConnection.videoOrientation = previewOrientation
-                videoOutput.connection(with: .video)?.videoOrientation = previewOrientation
-            }
+        var orientation: AVCaptureVideoOrientation = .portrait
+        switch currentOrientation {
+        case .portraitUpsideDown:
+            orientation = .portraitUpsideDown
+        case .landscapeLeft:
+            orientation = .landscapeRight
+        case .landscapeRight:
+            orientation = .landscapeLeft
+        default:
+            break
+        }
+        if let previewLayer = videoPreviewLayer, let previewConnection = videoPreviewLayer.connection,
+           previewConnection.isVideoOrientationSupported {
+            previewLayer.frame = cameraView.frame
+            previewConnection.videoOrientation = orientation
+            videoOutput.connection(with: .video)?.videoOrientation = orientation
         }
     }
 

--- a/ios/OpenBot/OpenBot/Controllers/CameraController.swift
+++ b/ios/OpenBot/OpenBot/Controllers/CameraController.swift
@@ -110,11 +110,11 @@ class CameraController: UIViewController, AVCaptureVideoDataOutputSampleBufferDe
     /// function to trigger the popup when camera permissions are not allowed.
     func createAllowAlert(alertFor: String) {
         let alert = UIAlertController(
-                title: "IMPORTANT",
-                message: "Please allow " + alertFor + " access for OpenBot",
+                title: Strings.important,
+                message: String(format: Strings.allowPermissionMessageFormat, alertFor),
                 preferredStyle: UIAlertController.Style.alert
         )
-        alert.addAction(UIAlertAction(title: "Allow " + alertFor, style: .cancel, handler: { (alert) -> Void in
+        alert.addAction(UIAlertAction(title: String(format: Strings.allowButtonFormat, alertFor), style: .cancel, handler: { (alert) -> Void in
             guard let url = URL(string: UIApplication.openSettingsURLString), !url.absoluteString.isEmpty else {
                 return
             }

--- a/ios/OpenBot/OpenBot/Controllers/DataCollection/ExpandSetting.swift
+++ b/ios/OpenBot/OpenBot/Controllers/DataCollection/ExpandSetting.swift
@@ -107,14 +107,17 @@ class expandSetting: UIView, UITextFieldDelegate, UIScrollViewDelegate {
 
     /// UI Function to create button for logs
     func createLogDataButton() {
-        _ = createLabels(value: Strings.logData, leadingAnchor: 10, topAnchor: 13, labelWidth: 100, labelHeight: 40)
+        let label = createLabels(value: Strings.logData, leadingAnchor: 10, topAnchor: 13, labelWidth: 100, labelHeight: 40)
         logData.isOn = false
         logData.setOn(false, animated: true)
         logData.onTintColor = Colors.title
         logData.addTarget(self, action: #selector(switchLogButton(_:)), for: .valueChanged)
         logData.translatesAutoresizingMaskIntoConstraints = false
         addSubview(logData)
-        logData.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: 90).isActive = true
+        logData.leadingAnchor.constraint(greaterThanOrEqualTo: label.trailingAnchor, constant: 12).isActive = true
+        let preferredPosition = logData.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: 90)
+        preferredPosition.priority = .defaultLow
+        preferredPosition.isActive = true
         logData.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: 10).isActive = true
     }
 

--- a/ios/OpenBot/OpenBot/Controllers/DataCollection/ExpandSetting.swift
+++ b/ios/OpenBot/OpenBot/Controllers/DataCollection/ExpandSetting.swift
@@ -244,7 +244,7 @@ class expandSetting: UIView, UITextFieldDelegate, UIScrollViewDelegate {
         server.heightAnchor.constraint(equalToConstant: 40).isActive = true;
         server.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: 10).isActive = true;
         server.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: 230).isActive = true;
-        serverDropDownLabel.text = "No Server"
+        serverDropDownLabel.text = Strings.noServer
         serverDropDownLabel.textColor = Colors.border
         serverDropDownLabel.frame = CGRect(x: 10, y: 0, width: 210, height: 40)
         server.addSubview(serverDropDownLabel);

--- a/ios/OpenBot/OpenBot/Controllers/HomePage/HomePageViewController.swift
+++ b/ios/OpenBot/OpenBot/Controllers/HomePage/HomePageViewController.swift
@@ -47,6 +47,7 @@ class HomePageViewController: CameraController, UICollectionViewDataSource, UICo
     /// Called after the view controller has loaded.
     override func viewDidLoad() {
         super.viewDidLoad()
+        tabBarItem.title = Strings.homeTab
 
         UITabBar.appearance().tintColor = traitCollection.userInterfaceStyle == .dark ? UIColor.white : UIColor.black;
         bluetoothDataController.shared.startScan()

--- a/ios/OpenBot/OpenBot/Controllers/ModelManagement/ModelManagementTable.swift
+++ b/ios/OpenBot/OpenBot/Controllers/ModelManagement/ModelManagementTable.swift
@@ -19,13 +19,16 @@ class ModelManagementTable: UITableViewController {
     var modelClassLabel = UILabel()
     var popupWindow = UIView();
     var models: [String]!
+    /// Functional filter keys, matched positionally against the (translated) dropdown display
+    /// text -- `updateModelItemList(type:)` switches on these, never on the localized labels.
+    private let modelFilterKeys = ["All", "AutoPilot", "Detector", "Navigation"]
     var selectedIndex: IndexPath!
     var popupWindowWidth: NSLayoutConstraint?
     var popupWindowHeight: NSLayoutConstraint?
     var popupWindowLeadingAnchor: NSLayoutConstraint?
     var popupWindowTopAnchor: NSLayoutConstraint?
     var dropDown = UIView()
-    let alert = UIAlertController(title: nil, message: "Please wait...", preferredStyle: .alert)
+    let alert = UIAlertController(title: nil, message: Strings.pleaseWaitMessage, preferredStyle: .alert)
     var timer = Timer()
     let autoSyncIcon = currentOrientation == .portrait ? UIImageView(frame: CGRect(x: width - 60, y: 15, width: 25, height: 20)) :
             UIImageView(frame: CGRect(x: height - 100, y: 15, width: 25, height: 20))
@@ -54,7 +57,7 @@ class ModelManagementTable: UITableViewController {
 
     override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView {
         let headerView = UIView(frame: CGRect(x: 0, y: 0, width: tableView.frame.width, height: 50));
-        let modelLabel = createLabel(text: "Model");
+        let modelLabel = createLabel(text: Strings.model);
         modelLabel.frame.size = CGSize(width: headerView.frame.width - 10, height: headerView.frame.height - 10);
         modelLabel.font = UIFont.boldSystemFont(ofSize: 25.0)
         headerView.addSubview(modelLabel)
@@ -134,7 +137,7 @@ class ModelManagementTable: UITableViewController {
         ddView.frame = CGRect(x: Int(width) / 2, y: 0, width: 100, height: 50);
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(showModelDropdown(_:)))
         ddView.addGestureRecognizer(tapGesture)
-        modelClassLabel = createLabel(text: "All");
+        modelClassLabel = createLabel(text: Strings.modelFilterAll);
         modelClassLabel.frame = CGRect(x: 0, y: 0, width: 100, height: 40);
         ddView.addSubview(modelClassLabel)
         let downwardImage = UIImageView()
@@ -154,12 +157,12 @@ class ModelManagementTable: UITableViewController {
         modelDropdown.textColor = traitCollection.userInterfaceStyle == .dark ? UIColor.white : UIColor.black;
         let dropDownView = UIView(frame: CGRect(x: width / 2 + 20, y: 100, width: width / 2 - 80, height: 200));
         view.addSubview(dropDownView);
-        modelDropdown.dataSource = ["All", "AutoPilot", "Detector", "Navigation"];
+        modelDropdown.dataSource = [Strings.modelFilterAll, Strings.modelFilterAutoPilot, Strings.modelFilterDetector, Strings.modelFilterNavigation];
         modelDropdown.anchorView = dropDownView
         modelDropdown.width = 100;
         modelDropdown.selectionAction = { [unowned self] (index: Int, item: String) in
             modelClassLabel.text = item
-            updateModelItemList(type: item)
+            updateModelItemList(type: modelFilterKeys[index])
         }
     }
 
@@ -168,19 +171,19 @@ class ModelManagementTable: UITableViewController {
         switch type {
         case "All":
             models = Common.loadAllModelsName()
-            modelClassLabel.text = "ALL"
+            modelClassLabel.text = Strings.modelFilterAllCaps
         case "AutoPilot":
             models = Common.returnAllModelItemsName(mode: "AUTOPILOT")
-            modelClassLabel.text = "AutoPilot"
+            modelClassLabel.text = Strings.modelFilterAutoPilot
         case "Detector":
             models = Common.returnAllModelItemsName(mode: "DETECTOR")
-            modelClassLabel.text = "Detector"
+            modelClassLabel.text = Strings.modelFilterDetector
         case "Navigation":
             models = []
-            modelClassLabel.text = "Navigation"
+            modelClassLabel.text = Strings.modelFilterNavigation
         default:
             models = Common.loadAllModelsName()
-            modelClassLabel.text = "ALL"
+            modelClassLabel.text = Strings.modelFilterAllCaps
         }
         updateTable()
     }

--- a/ios/OpenBot/OpenBot/Controllers/ModelManagement/PopupWindowView.swift
+++ b/ios/OpenBot/OpenBot/Controllers/ModelManagement/PopupWindowView.swift
@@ -81,10 +81,11 @@ class popupWindowView: UIView {
         heading.font = heading.font.withSize(22);
         addSubview(heading);
         heading.translatesAutoresizingMaskIntoConstraints = false;
-        heading.widthAnchor.constraint(equalToConstant: CGFloat(Strings.modelDetails.count * 10)).isActive = true;
+        let headingWidth = measuredWidth(of: Strings.modelDetails, font: heading.font) + 8
+        heading.widthAnchor.constraint(equalToConstant: headingWidth).isActive = true;
         heading.heightAnchor.constraint(equalToConstant: 40).isActive = true;
         heading.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: 10).isActive = true;
-        headingLeadingAnchor = heading.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: width / 2 - CGFloat(Strings.modelDetails.count * 5))
+        headingLeadingAnchor = heading.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: width / 2 - headingWidth / 2)
         headingLeadingAnchor.isActive = true;
     }
 
@@ -94,7 +95,7 @@ class popupWindowView: UIView {
         label.text = text;
         addSubview(label);
         label.translatesAutoresizingMaskIntoConstraints = false;
-        label.widthAnchor.constraint(equalToConstant: CGFloat(text.count * 12)).isActive = true;
+        label.widthAnchor.constraint(equalToConstant: measuredWidth(of: text, font: label.font) + 8).isActive = true;
         label.heightAnchor.constraint(equalToConstant: 40).isActive = true;
         label.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: leadingAnchor).isActive = true;
         label.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: topAnchor).isActive = true;
@@ -126,10 +127,10 @@ class popupWindowView: UIView {
     /// function to create tflite label.
     func createtfliteLabel() {
         let label = UILabel();
-        label.text = Strings.tflite;
+        label.text = Strings.tfliteLabel;
         addSubview(label)
         label.translatesAutoresizingMaskIntoConstraints = false;
-        label.widthAnchor.constraint(equalToConstant: CGFloat(Strings.tflite.count * 10)).isActive = true;
+        label.widthAnchor.constraint(equalToConstant: measuredWidth(of: Strings.tfliteLabel, font: label.font) + 8).isActive = true;
         label.heightAnchor.constraint(equalToConstant: 40).isActive = true;
         label.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor, constant: 0).isActive = true
         label.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: 60).isActive = true

--- a/ios/OpenBot/OpenBot/Controllers/ObjectTracking/ObjectTrackingSettings.swift
+++ b/ios/OpenBot/OpenBot/Controllers/ObjectTracking/ObjectTrackingSettings.swift
@@ -138,7 +138,7 @@ class ObjectTrackingSettings: UIView {
         label.text = text
         label.textColor = Colors.border
         label.frame.origin = CGPoint(x: leadingAnchor, y: topAnchor)
-        label.frame.size = resized(size: CGSize(width: text.count * 10, height: 40), basedOn: .height)
+        label.frame.size = resized(size: CGSize(width: measuredWidth(of: text, font: label.font) + 8, height: 40), basedOn: .height)
         return label
     }
 

--- a/ios/OpenBot/OpenBot/Controllers/ObjectTracking/ObjectTrackingSettings.swift
+++ b/ios/OpenBot/OpenBot/Controllers/ObjectTracking/ObjectTrackingSettings.swift
@@ -10,7 +10,9 @@ import DropDown
 class ObjectTrackingSettings: UIView {
     let autoModeButton = UISwitch()
     var autoModeLabel = UILabel()
+    var speedTitleLabel = UILabel()
     var speedLabel = UILabel()
+    var inputTitleLabel = UILabel()
     var modelDropdownLabel = UILabel()
     var imageInputLabel = UILabel()
     var threadLabel = UILabel()
@@ -58,9 +60,24 @@ class ObjectTrackingSettings: UIView {
         setDynamicSpeed()
         addSubview(createLabel(text: Strings.model, leadingAnchor: Int(adapted(dimensionSize: 20, to: .height)), topAnchor: Int(adapted(dimensionSize: 60, to: .height))))
         createModelDropDown()
-        addSubview(createLabel(text: Strings.speed, leadingAnchor: Int(adapted(dimensionSize: 20, to: .height)), topAnchor: Int(adapted(dimensionSize: 90, to: .height))))
+        speedTitleLabel = createLabel(text: Strings.speed, leadingAnchor: Int(adapted(dimensionSize: 20, to: .height)), topAnchor: Int(adapted(dimensionSize: 90, to: .height)))
+        speedTitleLabel.numberOfLines = 1
+        speedTitleLabel.adjustsFontSizeToFitWidth = true
+        speedTitleLabel.minimumScaleFactor = 0.5
+        speedTitleLabel.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(speedTitleLabel)
+        speedTitleLabel.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: adapted(dimensionSize: 20, to: .height)).isActive = true
+        speedTitleLabel.topAnchor.constraint(equalTo: topAnchor, constant: adapted(dimensionSize: 90, to: .height)).isActive = true
+        speedTitleLabel.widthAnchor.constraint(lessThanOrEqualToConstant: 100).isActive = true
         setupSpeed()
-        addSubview(createLabel(text: Strings.input, leadingAnchor: 180, topAnchor: Int(adapted(dimensionSize: 90, to: .height))))
+        inputTitleLabel = createLabel(text: Strings.input, leadingAnchor: 180, topAnchor: Int(adapted(dimensionSize: 90, to: .height)))
+        inputTitleLabel.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(inputTitleLabel)
+        inputTitleLabel.leadingAnchor.constraint(greaterThanOrEqualTo: speedLabel.trailingAnchor, constant: 12).isActive = true
+        let preferredInputPosition = inputTitleLabel.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: 180)
+        preferredInputPosition.priority = .defaultLow
+        preferredInputPosition.isActive = true
+        inputTitleLabel.topAnchor.constraint(equalTo: topAnchor, constant: adapted(dimensionSize: 90, to: .height)).isActive = true
         setupInput();
         addSubview(createLabel(text: Strings.object, leadingAnchor: Int(adapted(dimensionSize: 20, to: .height)), topAnchor: Int(adapted(dimensionSize: 120, to: .height))))
         setupObjectDropDown()
@@ -252,15 +269,27 @@ class ObjectTrackingSettings: UIView {
 
     /// function to setup image size.
     func setupInput() {
-        imageInputLabel.frame = CGRect(x: width - 80, y: adapted(dimensionSize: 90, to: .height), width: 100, height: 40)
         imageInputLabel.text = selectedModel?.inputSize
+        imageInputLabel.textColor = Colors.border
+        imageInputLabel.translatesAutoresizingMaskIntoConstraints = false
         addSubview(imageInputLabel)
+        imageInputLabel.leadingAnchor.constraint(greaterThanOrEqualTo: inputTitleLabel.trailingAnchor, constant: 12).isActive = true
+        let preferredImageInputPosition = imageInputLabel.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: width - 80)
+        preferredImageInputPosition.priority = .defaultLow
+        preferredImageInputPosition.isActive = true
+        imageInputLabel.topAnchor.constraint(equalTo: topAnchor, constant: adapted(dimensionSize: 90, to: .height)).isActive = true
     }
 
     /// function to create speed label to display fps
     func setupSpeed() {
         speedLabel = createLabel(text: "*** fps", leadingAnchor: 90, topAnchor: Int(adapted(dimensionSize: 90, to: .height)))
+        speedLabel.translatesAutoresizingMaskIntoConstraints = false
         addSubview(speedLabel)
+        speedLabel.leadingAnchor.constraint(greaterThanOrEqualTo: speedTitleLabel.trailingAnchor, constant: 12).isActive = true
+        let preferredPosition = speedLabel.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: 90)
+        preferredPosition.priority = .defaultLow
+        preferredPosition.isActive = true
+        speedLabel.topAnchor.constraint(equalTo: topAnchor, constant: adapted(dimensionSize: 90, to: .height)).isActive = true
     }
     
     /// function to create checkbox to enable or disable dynamic speed

--- a/ios/OpenBot/OpenBot/Controllers/ObjectTracking/ObjectTrackingSettings.swift
+++ b/ios/OpenBot/OpenBot/Controllers/ObjectTracking/ObjectTrackingSettings.swift
@@ -9,6 +9,7 @@ import DropDown
 /// Implementation of Object tracking settings.
 class ObjectTrackingSettings: UIView {
     let autoModeButton = UISwitch()
+    var autoModeLabel = UILabel()
     var speedLabel = UILabel()
     var modelDropdownLabel = UILabel()
     var imageInputLabel = UILabel()
@@ -48,7 +49,8 @@ class ObjectTrackingSettings: UIView {
         swipeUp.direction = .up
         addGestureRecognizer(swipeUp)
         createBar()
-        addSubview(createLabel(text: Strings.autoMode, leadingAnchor: Int(adapted(dimensionSize: 20, to: .height)), topAnchor: Int(adapted(dimensionSize: 15, to: .height))));
+        autoModeLabel = createLabel(text: Strings.autoMode, leadingAnchor: Int(adapted(dimensionSize: 20, to: .height)), topAnchor: Int(adapted(dimensionSize: 15, to: .height)));
+        addSubview(autoModeLabel);
         createBluetoothIcon()
         createCameraIcon()
         createSwitchButton()
@@ -128,7 +130,10 @@ class ObjectTrackingSettings: UIView {
         autoModeButton.translatesAutoresizingMaskIntoConstraints = false
         addSubview(autoModeButton)
         autoModeButton.widthAnchor.constraint(equalToConstant: 40).isActive = true
-        autoModeButton.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: 120).isActive = true
+        autoModeButton.leadingAnchor.constraint(greaterThanOrEqualTo: autoModeLabel.trailingAnchor, constant: 12).isActive = true
+        let preferredPosition = autoModeButton.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: 120)
+        preferredPosition.priority = .defaultLow
+        preferredPosition.isActive = true
         autoModeButton.topAnchor.constraint(equalTo: topAnchor, constant: 25).isActive = true
     }
 

--- a/ios/OpenBot/OpenBot/Controllers/PointGoalNavigation/PointGoalFragment.swift
+++ b/ios/OpenBot/OpenBot/Controllers/PointGoalNavigation/PointGoalFragment.swift
@@ -123,7 +123,7 @@ class PointGoalFragment: UIViewController, ARSCNViewDelegate, UITextFieldDelegat
         goalReachedText.leadingAnchor.constraint(equalTo: infoText.leadingAnchor, constant: 0).isActive = true
         goalReachedText.topAnchor.constraint(equalTo: infoText.bottomAnchor, constant: 30).isActive = true
 
-        let stopButton = createLabelButtons(title: Strings.stop, selector: #selector(stop(_:)))
+        let stopButton = createLabelButtons(title: Strings.stopLabel, selector: #selector(stop(_:)))
         infoMessageRect.addSubview(stopButton)
         stopButton.translatesAutoresizingMaskIntoConstraints = false
         stopButton.leadingAnchor.constraint(equalTo: infoMessageRect.leadingAnchor, constant: width / 2 - 30).isActive = true
@@ -197,7 +197,7 @@ class PointGoalFragment: UIViewController, ARSCNViewDelegate, UITextFieldDelegat
         cancelButton.translatesAutoresizingMaskIntoConstraints = false
         cancelButton.leadingAnchor.constraint(equalTo: setGoalText.leadingAnchor, constant: 0).isActive = true
         cancelButton.bottomAnchor.constraint(equalTo: setGoalRect.bottomAnchor, constant: -15).isActive = true
-        let startButton = createLabelButtons(title: Strings.start, selector: #selector(doneFun(_:)))
+        let startButton = createLabelButtons(title: Strings.startLabel, selector: #selector(doneFun(_:)))
         setGoalRect.addSubview(startButton)
         startButton.translatesAutoresizingMaskIntoConstraints = false
         startButton.bottomAnchor.constraint(equalTo: setGoalRect.bottomAnchor, constant: -15).isActive = true

--- a/ios/OpenBot/OpenBot/Controllers/PointGoalNavigation/PointGoalFragment.swift
+++ b/ios/OpenBot/OpenBot/Controllers/PointGoalNavigation/PointGoalFragment.swift
@@ -117,7 +117,7 @@ class PointGoalFragment: UIViewController, ARSCNViewDelegate, UITextFieldDelegat
         infoText.translatesAutoresizingMaskIntoConstraints = false
         infoText.leadingAnchor.constraint(equalTo: infoMessageRect.leadingAnchor, constant: 30).isActive = true
         infoText.topAnchor.constraint(equalTo: infoMessageRect.topAnchor, constant: 30).isActive = true
-        let goalReachedText = createLabel(text: "Goal reached", fontSize: 16)
+        let goalReachedText = createLabel(text: Strings.goalReachedMessage, fontSize: 16)
         infoMessageRect.addSubview(goalReachedText)
         goalReachedText.translatesAutoresizingMaskIntoConstraints = false
         goalReachedText.leadingAnchor.constraint(equalTo: infoText.leadingAnchor, constant: 0).isActive = true

--- a/ios/OpenBot/OpenBot/Controllers/Profile/EditProfileFragment.swift
+++ b/ios/OpenBot/OpenBot/Controllers/Profile/EditProfileFragment.swift
@@ -19,7 +19,7 @@ class editProfileFragment: UIViewController, UIImagePickerControllerDelegate, UI
     private let authentication = Authentication()
     private var firstName: UILabel!
     private var lastName: UILabel!
-    let alert = UIAlertController(title: "Loading", message: "Please wait while we load the profile...", preferredStyle: .alert)
+    let alert = UIAlertController(title: Strings.loadingTitle, message: Strings.loadingProfileMessage, preferredStyle: .alert)
     private var email: UILabel!
     private var dob: UILabel!
     private var firstNameField: UITextField!
@@ -101,10 +101,10 @@ class editProfileFragment: UIViewController, UIImagePickerControllerDelegate, UI
      This function creates the labels for the text fields.
      */
     private func createLabels() {
-        firstName = CustomLabel(text: "First Name", fontSize: 16, fontColor: traitCollection.userInterfaceStyle == .dark ? UIColor.white : UIColor.black, frame: CGRect(x: 26, y: 0, width: 150, height: 40))
-        lastName = CustomLabel(text: "Last Name", fontSize: 16, fontColor: traitCollection.userInterfaceStyle == .dark ? UIColor.white : UIColor.black, frame: CGRect(x: 26, y: (firstName.frame.origin.y + 100.0), width: 150, height: 40))
-        dob = CustomLabel(text: "Date Of Birth", fontSize: 16, fontColor: traitCollection.userInterfaceStyle == .dark ? UIColor.white : UIColor.black, frame: CGRect(x: 26, y: (lastName.frame.origin.y + 100.0), width: 150, height: 40))
-        email = CustomLabel(text: "Email", fontSize: 16, fontColor: traitCollection.userInterfaceStyle == .dark ? UIColor.white : UIColor.black, frame: CGRect(x: 26, y: (dob.frame.origin.y + 100.0), width: 150, height: 40))
+        firstName = CustomLabel(text: Strings.firstNameFieldLabel, fontSize: 16, fontColor: traitCollection.userInterfaceStyle == .dark ? UIColor.white : UIColor.black, frame: CGRect(x: 26, y: 0, width: 150, height: 40))
+        lastName = CustomLabel(text: Strings.lastNameFieldLabel, fontSize: 16, fontColor: traitCollection.userInterfaceStyle == .dark ? UIColor.white : UIColor.black, frame: CGRect(x: 26, y: (firstName.frame.origin.y + 100.0), width: 150, height: 40))
+        dob = CustomLabel(text: Strings.dateOfBirthFieldLabel, fontSize: 16, fontColor: traitCollection.userInterfaceStyle == .dark ? UIColor.white : UIColor.black, frame: CGRect(x: 26, y: (lastName.frame.origin.y + 100.0), width: 150, height: 40))
+        email = CustomLabel(text: Strings.emailFieldLabel, fontSize: 16, fontColor: traitCollection.userInterfaceStyle == .dark ? UIColor.white : UIColor.black, frame: CGRect(x: 26, y: (dob.frame.origin.y + 100.0), width: 150, height: 40))
         scrollView.addSubview(firstName);
         scrollView.addSubview(lastName);
         scrollView.addSubview(dob);
@@ -117,7 +117,7 @@ class editProfileFragment: UIViewController, UIImagePickerControllerDelegate, UI
     private func createTextFields() {
         firstNameField = CustomTextField(frame: CGRect(x: 17, y: firstName.frame.origin.y + adapted(dimensionSize: 30, to: .height), width: width - 34, height: 47));
         view.addSubview(firstNameField);
-        setTextField(textField: firstNameField, value: getFirstName(name: Auth.auth().currentUser?.displayName ?? "Unknown"));
+        setTextField(textField: firstNameField, value: getFirstName(name: Auth.auth().currentUser?.displayName ?? Strings.unknownFallback));
         lastNameField = CustomTextField(frame: CGRect(x: 17, y: lastName.frame.origin.y + adapted(dimensionSize: 30, to: .height), width: width - 34, height: 47));
         setTextField(textField: lastNameField, value: getLastName(name: Auth.auth().currentUser?.displayName ?? ""));
         dobField = CustomTextField(frame: CGRect(x: 17, y: dob.frame.origin.y + adapted(dimensionSize: 30, to: .height), width: width - 34, height: 47));
@@ -247,9 +247,9 @@ class editProfileFragment: UIViewController, UIImagePickerControllerDelegate, UI
      Function to create button named cancel and done.
      */
     private func createButtons() {
-        let cancelBtn = CustomButton(text: "Cancel", frame: CGRect(x: 17, y: email.bottom + adapted(dimensionSize: 60, to: .height), width: 147, height: 47), selector: #selector(cancel))
+        let cancelBtn = CustomButton(text: Strings.cancel, frame: CGRect(x: 17, y: email.bottom + adapted(dimensionSize: 60, to: .height), width: 147, height: 47), selector: #selector(cancel))
         scrollView.addSubview(cancelBtn);
-        saveChangesBtn = CustomButton(text: "Save Changes", frame: CGRect(x: cancelBtn.frame.origin.x + 194.0, y: cancelBtn.frame.origin.y, width: 147, height: 47), selector: #selector(saveChanges))
+        saveChangesBtn = CustomButton(text: Strings.saveChangesButton, frame: CGRect(x: cancelBtn.frame.origin.x + 194.0, y: cancelBtn.frame.origin.y, width: 147, height: 47), selector: #selector(saveChanges))
         scrollView.addSubview(saveChangesBtn)
         saveChangesBtn.backgroundColor = Colors.title
         saveChangesBtn.setTitleColor(UIColor.white, for: .normal);
@@ -283,7 +283,7 @@ class editProfileFragment: UIViewController, UIImagePickerControllerDelegate, UI
                         print("Error updating profile: \(error.localizedDescription)")
                     } else {
                         self.alert.dismiss(animated: true);
-                        self.showToast("Profile Updated Successfully", icon: UIImage(named: "check")!);
+                        self.showToast(Strings.profileUpdatedSuccessToast, icon: UIImage(named: "check")!);
                     }
                 }
             }
@@ -389,7 +389,7 @@ class editProfileFragment: UIViewController, UIImagePickerControllerDelegate, UI
      Toast message on error while loading profile picture
      */
     func imageLoadFailed() {
-        showToast("Error while loading profile picture", icon: UIImage(named: "check")!);
+        showToast(Strings.profilePictureLoadErrorToast, icon: UIImage(named: "check")!);
         alert.dismiss(animated: true);
     }
 
@@ -399,7 +399,7 @@ class editProfileFragment: UIViewController, UIImagePickerControllerDelegate, UI
     func setupNavigationBarItem() {
         if UIImage(named: "back") != nil {
             let backNavigationIcon = (UIImage(named: "back")?.withRenderingMode(.alwaysOriginal))!
-            let newBackButton = UIBarButtonItem(image: backNavigationIcon, title: "Edit Profile", target: self, action: #selector(back(sender:)), titleColor: Colors.navigationColor ?? .white)
+            let newBackButton = UIBarButtonItem(image: backNavigationIcon, title: Strings.editProfile, target: self, action: #selector(back(sender:)), titleColor: Colors.navigationColor ?? .white)
             navigationItem.leftBarButtonItem = newBackButton
         }
     }

--- a/ios/OpenBot/OpenBot/Controllers/Profile/ProfileFragment.swift
+++ b/ios/OpenBot/OpenBot/Controllers/Profile/ProfileFragment.swift
@@ -28,6 +28,7 @@ class profileFragment: UIViewController {
      */
     override func viewDidLoad() {
         super.viewDidLoad()
+        tabBarItem.title = Strings.profileTab
         createMyProfileLabel();
         navigationController?.navigationBar.setBackgroundImage(UIImage(), for: .default)
         navigationController?.navigationBar.shadowImage = UIImage()

--- a/ios/OpenBot/OpenBot/Controllers/Profile/ProfileFragment.swift
+++ b/ios/OpenBot/OpenBot/Controllers/Profile/ProfileFragment.swift
@@ -12,7 +12,7 @@ import GoogleSignIn
 class profileFragment: UIViewController {
     let shadowSheet = UIView(frame: UIScreen.main.bounds);
     var logoutView = UIView()
-    let alert = UIAlertController(title: "Loading", message: "Please wait while we load the profile...", preferredStyle: .alert)
+    let alert = UIAlertController(title: Strings.loadingTitle, message: Strings.loadingProfileMessage, preferredStyle: .alert)
     var firstLabel = UILabel()
     var secondLabel = UILabel()
     var signInBtn = GoogleSignInBtn()
@@ -77,7 +77,7 @@ class profileFragment: UIViewController {
      Function to create My profile Label on top
      */
     private func createMyProfileLabel() {
-        let label = CustomLabel(text: "My Profile", fontSize: 15, fontColor: Colors.textColor ?? .black, frame: CGRect(origin: .zero, size: CGSize(width: 200, height: 40)));
+        let label = CustomLabel(text: Strings.myProfileHeading, fontSize: 15, fontColor: Colors.textColor ?? .black, frame: CGRect(origin: .zero, size: CGSize(width: 200, height: 40)));
         label.font = HelveticaNeue.regular(size: 15);
         label.translatesAutoresizingMaskIntoConstraints = false;
         view.addSubview(label)
@@ -90,8 +90,12 @@ class profileFragment: UIViewController {
      Function to create the message for sign-in
      */
     private func createPleaseSignInLabel() {
-        firstLabel = CustomLabel(text: "Set up your profile by signing in with", fontSize: 16, fontColor: Colors.textColor ?? .black, frame: CGRect(x: width / 2 - 135, y: 20, width: 270, height: 40));
-        secondLabel = CustomLabel(text: "your Google account.", fontSize: 16, fontColor: Colors.textColor ?? .black, frame: CGRect(x: width / 2 - 80, y: firstLabel.bottom - 5, width: 160, height: 40));
+        // Full-width and center-aligned rather than a box tuned for the English text's pixel
+        // width, since translations vary too much in length to keep a fixed narrow box centered.
+        firstLabel = CustomLabel(text: Strings.setupProfilePromptLine1, fontSize: 16, fontColor: Colors.textColor ?? .black, frame: CGRect(x: 20, y: 20, width: width - 40, height: 40));
+        firstLabel.textAlignment = .center;
+        secondLabel = CustomLabel(text: Strings.setupProfilePromptLine2, fontSize: 16, fontColor: Colors.textColor ?? .black, frame: CGRect(x: 20, y: firstLabel.bottom - 5, width: width - 40, height: 40));
+        secondLabel.textAlignment = .center;
         guestView.addSubview(firstLabel);
         guestView.addSubview(secondLabel);
     }
@@ -110,12 +114,12 @@ class profileFragment: UIViewController {
      Function to create labels for edit profile and logout
      */
     private func createEditProfileAndLogoutLabel() {
-        editProfileLabel = CustomLabel(text: "Edit Profile", fontSize: 16, fontColor: Colors.textColor ?? .black, frame: CGRect(x: userImgView.right + 72, y: 0, width: 120, height: 50))
+        editProfileLabel = CustomLabel(text: Strings.editProfile, fontSize: 16, fontColor: Colors.textColor ?? .black, frame: CGRect(x: userImgView.right + 72, y: 0, width: 120, height: 50))
         signInView.addSubview(editProfileLabel);
         editProfileLabel.isUserInteractionEnabled = true;
         let tapOnEditProfile = UITapGestureRecognizer(target: self, action: #selector(editProfileHandler))
         editProfileLabel.addGestureRecognizer(tapOnEditProfile);
-        logoutLabel = CustomLabel(text: "Logout", fontSize: 16, fontColor: Colors.textColor ?? .black, frame: CGRect(x: userImgView.right + 72, y: editProfileLabel.bottom + 25, width: 120, height: 50))
+        logoutLabel = CustomLabel(text: Strings.logoutMenuItem, fontSize: 16, fontColor: Colors.textColor ?? .black, frame: CGRect(x: userImgView.right + 72, y: editProfileLabel.bottom + 25, width: 120, height: 50))
         signInView.addSubview(logoutLabel);
         logoutLabel.isUserInteractionEnabled = true;
         let tapOnLogout = UITapGestureRecognizer(target: self, action: #selector(logoutHandler))

--- a/ios/OpenBot/OpenBot/Controllers/Project/ProjectFragement.swift
+++ b/ios/OpenBot/OpenBot/Controllers/Project/ProjectFragement.swift
@@ -39,6 +39,7 @@ class projectFragment: UIViewController, UICollectionViewDataSource, UICollectio
     */
     override func viewDidLoad() {
         super.viewDidLoad()
+        tabBarItem.title = Strings.projectsTab
         baseView?.addSubview(animationView);
         animationView.backgroundColor = Colors.title
         view.addSubview(signInView);

--- a/ios/OpenBot/OpenBot/Controllers/Project/ProjectFragement.swift
+++ b/ios/OpenBot/OpenBot/Controllers/Project/ProjectFragement.swift
@@ -25,7 +25,7 @@ class projectFragment: UIViewController, UICollectionViewDataSource, UICollectio
     var vehicleControl = Control();
     @IBOutlet weak var openCodeWebView: UIView!
     private var command: String = ""
-    private let alert = UIAlertController(title: nil, message: "Please wait...", preferredStyle: .alert)
+    private let alert = UIAlertController(title: nil, message: Strings.pleaseWaitMessage, preferredStyle: .alert)
     private var allProjectCommands: [ProjectData] = UserDefaults.getALlProjectsDataFromUserDefaults()
     private var myProjectLabel: CustomLabel = CustomLabel(frame: .zero)
     var fileName: String = String()
@@ -157,7 +157,7 @@ class projectFragment: UIViewController, UICollectionViewDataSource, UICollectio
      Function to create my project label
      */
     func createMyProjectLabel() {
-        myProjectLabel = CustomLabel(text: "My Projects", fontSize: 15, fontColor: Colors.textColor ?? .black, frame: CGRect(origin: .zero, size: CGSize(width: 200, height: 40)));
+        myProjectLabel = CustomLabel(text: Strings.myProjectsHeading, fontSize: 15, fontColor: Colors.textColor ?? .black, frame: CGRect(origin: .zero, size: CGSize(width: 200, height: 40)));
         myProjectLabel.font = HelveticaNeue.regular(size: 15);
         myProjectLabel.translatesAutoresizingMaskIntoConstraints = false;
         view.addSubview(myProjectLabel)
@@ -169,8 +169,12 @@ class projectFragment: UIViewController, UICollectionViewDataSource, UICollectio
      Functions to create the message
      */
     func createPleaseSignInLabel() {
-        let firstLabel = CustomLabel(text: "Please sign in first to access your", fontSize: 16, fontColor: Colors.textColor ?? .black, frame: CGRect(x: width / 2 - 115, y: 20, width: 250, height: 40));
-        let secondLabel = CustomLabel(text: "projects.", fontSize: 16, fontColor: Colors.textColor ?? .black, frame: CGRect(x: width / 2 - 32.5, y: firstLabel.bottom - 5, width: 65, height: 40));
+        // Full-width and center-aligned rather than a box tuned for the English text's pixel
+        // width, since translations vary too much in length to keep a fixed narrow box centered.
+        let firstLabel = CustomLabel(text: Strings.pleaseSignInProjectsLine1, fontSize: 16, fontColor: Colors.textColor ?? .black, frame: CGRect(x: 20, y: 20, width: width - 40, height: 40));
+        firstLabel.textAlignment = .center;
+        let secondLabel = CustomLabel(text: Strings.pleaseSignInProjectsLine2, fontSize: 16, fontColor: Colors.textColor ?? .black, frame: CGRect(x: 20, y: firstLabel.bottom - 5, width: width - 40, height: 40));
+        secondLabel.textAlignment = .center;
         signInView.addSubview(firstLabel);
         signInView.addSubview(secondLabel)
     }
@@ -179,10 +183,10 @@ class projectFragment: UIViewController, UICollectionViewDataSource, UICollectio
      Function will generate ui view when no project at drive
      */
     func createNoProjectMessage() {
-        let firstLabel = CustomLabel(text: "Oops! No projects found.", fontSize: 22, fontColor: Colors.title ?? .blue, frame: CGRect(x: width / 2 - 140, y: 20, width: 280, height: 40));
+        let firstLabel = CustomLabel(text: Strings.noProjectsFoundHeading, fontSize: 22, fontColor: Colors.title ?? .blue, frame: CGRect(x: width / 2 - 140, y: 20, width: 280, height: 40));
         firstLabel.textAlignment = .center;
         firstLabel.font = HelveticaNeue.bold(size: 16);
-        let label = CustomLabel(text: "Looks like there are no projects\nin your google drive yet.",
+        let label = CustomLabel(text: Strings.noProjectsFoundBody,
                 fontSize: 18,
                 fontColor: traitCollection.userInterfaceStyle == .dark ? UIColor.white : UIColor.black,
                 frame: CGRect(x: width / 2 - 140, y: firstLabel.bottom - 5, width: 280, height: 80))
@@ -718,9 +722,9 @@ class projectFragment: UIViewController, UICollectionViewDataSource, UICollectio
     }
 
     private func createDeleteProject() {
-        let alertController = UIAlertController(title: "Delete this file", message: "You cannot restore this file later", preferredStyle: .alert)
-        let cancelAction = UIAlertAction(title: "Cancel", style: .cancel, handler: nil)
-        let deleteAction = UIAlertAction(title: "Delete", style: .destructive) { (_) in
+        let alertController = UIAlertController(title: Strings.deleteFileTitle, message: Strings.deleteFileMessage, preferredStyle: .alert)
+        let cancelAction = UIAlertAction(title: Strings.cancel, style: .cancel, handler: nil)
+        let deleteAction = UIAlertAction(title: Strings.deleteAction, style: .destructive) { (_) in
             self.isLoading = true;
             self.animateFloatingView();
             self.deleteProject(projectName: self.fileName, projectId: self.projectId) { error, deleteCount in

--- a/ios/OpenBot/OpenBot/Controllers/QrScanner/ScannerFragment.swift
+++ b/ios/OpenBot/OpenBot/Controllers/QrScanner/ScannerFragment.swift
@@ -13,7 +13,7 @@ class scannerFragment: CameraController,autopilotDelegate {
     var previewLayer = AVCaptureVideoPreviewLayer();
     var whiteSheet = openCodeRunBottomSheet(frame: UIScreen.main.bounds)
     @IBOutlet weak var cancelBtn: UIView!
-    let alert = UIAlertController(title: "Loading", message: "Please wait while we load data...", preferredStyle: .alert)
+    let alert = UIAlertController(title: Strings.loadingTitle, message: Strings.loadingDataMessage, preferredStyle: .alert)
     var userToken: String = ""
     private var commands: String = ""
     private var projectFileId: String = "";
@@ -88,7 +88,7 @@ class scannerFragment: CameraController,autopilotDelegate {
      Create Heading of Fragment
      */
     private func createScanHeading() {
-        heading = CustomLabel.init(text: "Scan Qr Code", fontSize: 22, fontColor: Colors.textColor ?? .black, frame: CGRect(x: width / 2 - 65, y: 20, width: 145, height: 40))
+        heading = CustomLabel.init(text: Strings.scanQrCodeHeading, fontSize: 22, fontColor: Colors.textColor ?? .black, frame: CGRect(x: width / 2 - 65, y: 20, width: 145, height: 40))
         heading.textAlignment = .center;
         firstHalfView.addSubview(heading);
     }
@@ -97,7 +97,7 @@ class scannerFragment: CameraController,autopilotDelegate {
      Create Message of Fragment
      */
     private func createScanMessage() {
-        let message = "Place qr code inside the frame to scan. Please avoid shake to get results quickly."
+        let message = Strings.scanInstructions
         let font = UIFont(name: "HelveticaNeue", size: 15)!
         let messageSize = (message as NSString).boundingRect(with: CGSize(width: 320, height: CGFloat.greatestFiniteMagnitude), options: .usesLineFragmentOrigin, attributes: [.font: font], context: nil)
         let messageHeight = ceil(messageSize.height)
@@ -273,7 +273,7 @@ class scannerFragment: CameraController,autopilotDelegate {
      Function to create Error Heading  mukerian
      */
     private func createErrorHeading() {
-        let errorHeading = CustomLabel(text: "Error",
+        let errorHeading = CustomLabel(text: Strings.errorHeading,
                 fontSize: 18, fontColor: Colors.textColor ?? .black, frame: CGRect(x: 19, y: 23, width: 60, height: 40));
         errorHeading.font = HelveticaNeue.bold(size: 15);
         bottomSheet.addSubview(errorHeading);
@@ -283,7 +283,7 @@ class scannerFragment: CameraController,autopilotDelegate {
      Function to create Error Message
      */
     private func createErrorMsg() {
-        let msg = CustomLabel(text: "Oops! Something went wrong.Please try again.", fontSize: 15, fontColor: Colors.textColor ?? .black, frame: CGRect(x: 19, y: 57, width: 330, height: 40));
+        let msg = CustomLabel(text: Strings.genericErrorMessage, fontSize: 15, fontColor: Colors.textColor ?? .black, frame: CGRect(x: 19, y: 57, width: 330, height: 40));
         bottomSheet.addSubview(msg);
     }
 
@@ -293,7 +293,7 @@ class scannerFragment: CameraController,autopilotDelegate {
     private func createScanQrBtn() {
         let scanQr = UIButton(frame: CGRect(x: 19, y: 120, width: 120, height: 40));
         scanQr.backgroundColor = Colors.title;
-        scanQr.setTitle("Scan QR", for: .normal);
+        scanQr.setTitle(Strings.scanQrButton, for: .normal);
         scanQr.addTarget(nil, action: #selector(scan), for: .touchUpInside);
         scanQr.layer.cornerRadius = 10;
         bottomSheet.addSubview(scanQr);
@@ -343,7 +343,7 @@ class scannerFragment: CameraController,autopilotDelegate {
     func setupNavigationBarItem() {
         if UIImage(named: "back") != nil {
             let backNavigationIcon = (UIImage(named: "back")?.withRenderingMode(.alwaysOriginal))!
-            let newBackButton = UIBarButtonItem(image: backNavigationIcon, title: "Qr Scanner", target: self, action: #selector(back(sender:)), titleColor: Colors.navigationColor ?? .white)
+            let newBackButton = UIBarButtonItem(image: backNavigationIcon, title: Strings.qrScannerNavTitle, target: self, action: #selector(back(sender:)), titleColor: Colors.navigationColor ?? .white)
             navigationItem.leftBarButtonItem = newBackButton
         }
     }

--- a/ios/OpenBot/OpenBot/Controllers/RobotInfo/RobotInfoFrame.swift
+++ b/ios/OpenBot/OpenBot/Controllers/RobotInfo/RobotInfoFrame.swift
@@ -127,7 +127,7 @@ class RobotInfoFrame: UIViewController {
 
     /// creates heading label
     func createRobotTypeHeading() {
-        robotType = createHeadings(text: "Robot Type")
+        robotType = createHeadings(text: Strings.robotTypeHeading)
         robotType.frame.origin = CGPoint(x: 10, y: topPadding + adapted(dimensionSize: 30, to: .height))
     }
 
@@ -158,7 +158,7 @@ class RobotInfoFrame: UIViewController {
 
     /// creates sensors heading
     func createSensorHeading() {
-        sensorHeading = createHeadings(text: "Sensors")
+        sensorHeading = createHeadings(text: Strings.sensorsHeading)
     }
 
     /// creates checkboxes for sensors
@@ -608,7 +608,7 @@ class RobotInfoFrame: UIViewController {
         if sonarData != "" {
             let index = sonarData.index(after: sonarData.startIndex)
             let actualSonarValue = min(Int(String(sonarData[index...])) ?? 0, 300)
-            sonar.text = "Sonar " + String(actualSonarValue) + " cm"
+            sonar.text = String(format: Strings.sonarReadingFormat, String(actualSonarValue))
         }
     }
 
@@ -617,7 +617,7 @@ class RobotInfoFrame: UIViewController {
         let voltageData = bluetooth.voltageDivider
         if voltageData != "" {
             let index = voltageData.index(after: voltageData.startIndex)
-            battery.text = "Battery " + String(voltageData[index...]) + " V"
+            battery.text = String(format: Strings.batteryReadingFormat, String(voltageData[index...]))
         }
     }
 

--- a/ios/OpenBot/OpenBot/Controllers/RobotInfo/RobotInfoFrame.swift
+++ b/ios/OpenBot/OpenBot/Controllers/RobotInfo/RobotInfoFrame.swift
@@ -224,7 +224,7 @@ class RobotInfoFrame: UIViewController {
         motorLabel = createLabels(text: Strings.motors, topAnchor: 610, leadingAnchor: 20)
         forwardButton = createButton(width: 80, height: 40, title: Strings.forward, leadingAnchor: 70, topAnchor: 610, action: #selector(forwardButton(_:)))
         backwardButton = createButton(width: 90, height: 40, title: Strings.backward, leadingAnchor: 180, topAnchor: 610, action: #selector(backwardButton(_:)))
-        stopButton = createButton(width: 60, height: 40, title: Strings.stop, leadingAnchor: 290, topAnchor: 610, action: #selector(stopButton(_:)))
+        stopButton = createButton(width: 60, height: 40, title: Strings.stopLabel, leadingAnchor: 290, topAnchor: 610, action: #selector(stopButton(_:)))
     }
 
 /// creates heading and slider for lights
@@ -258,10 +258,10 @@ class RobotInfoFrame: UIViewController {
         let label = UILabel()
         label.text = text
         label.textColor = Colors.border
-        label.frame.size.width = CGFloat(text.count * 15)
+        label.font = HelveticaNeue.bold(size: 12)
+        label.frame.size.width = measuredWidth(of: text, font: label.font) + 8
         label.frame.size.height = 40
         view.addSubview(label)
-        label.font = HelveticaNeue.bold(size: 12)
         return label
     }
 
@@ -270,8 +270,8 @@ class RobotInfoFrame: UIViewController {
         let label = UILabel()
         label.text = text
         label.textColor = Colors.border
-        label.frame.size.width = CGFloat(text.count * 10)
         label.font = label.font.withSize(12)
+        label.frame.size.width = measuredWidth(of: text, font: label.font) + 8
         label.frame.size.height = 40
         view.addSubview(label)
         label.frame.origin.x = leadingAnchor
@@ -486,7 +486,7 @@ class RobotInfoFrame: UIViewController {
     /// function to update the robot name.
     func setRobotName() {
         robotName.text = getRobotName()
-        robotName.frame.size.width = CGFloat(getRobotName().count * 10)
+        robotName.frame.size.width = measuredWidth(of: getRobotName(), font: robotName.font) + 8
     }
 
     /// function to check whether voltage is available on the robot.

--- a/ios/OpenBot/OpenBot/Controllers/Settings/LanguageApplyingView.swift
+++ b/ios/OpenBot/OpenBot/Controllers/Settings/LanguageApplyingView.swift
@@ -1,0 +1,50 @@
+//
+// Created for in-app language switching.
+//
+
+import UIKit
+
+/// Branded transition covering the window while `LocalizationManager` rebuilds the root view
+/// controller, playing the same role as Android's `activity_language_applying` screen.
+final class LanguageApplyingView: UIView {
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        backgroundColor = .systemBackground
+
+        let logo = UIImageView(image: Images.openBotLogo)
+        logo.contentMode = .scaleAspectFit
+        logo.translatesAutoresizingMaskIntoConstraints = false
+
+        let spinner = UIActivityIndicatorView(style: .medium)
+        spinner.color = Colors.title
+        spinner.startAnimating()
+        spinner.translatesAutoresizingMaskIntoConstraints = false
+
+        let message = UILabel()
+        message.text = Strings.applyingLanguage
+        message.textColor = Colors.border
+        message.font = UIFont.systemFont(ofSize: 14)
+        message.translatesAutoresizingMaskIntoConstraints = false
+
+        addSubview(logo)
+        addSubview(spinner)
+        addSubview(message)
+
+        NSLayoutConstraint.activate([
+            logo.centerXAnchor.constraint(equalTo: centerXAnchor),
+            logo.centerYAnchor.constraint(equalTo: centerYAnchor, constant: -40),
+            logo.widthAnchor.constraint(equalToConstant: 96),
+            logo.heightAnchor.constraint(equalToConstant: 96),
+
+            spinner.centerXAnchor.constraint(equalTo: centerXAnchor),
+            spinner.topAnchor.constraint(equalTo: logo.bottomAnchor, constant: 24),
+
+            message.centerXAnchor.constraint(equalTo: centerXAnchor),
+            message.topAnchor.constraint(equalTo: spinner.bottomAnchor, constant: 16),
+        ])
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/ios/OpenBot/OpenBot/Controllers/Settings/LanguagePickerViewController.swift
+++ b/ios/OpenBot/OpenBot/Controllers/Settings/LanguagePickerViewController.swift
@@ -1,0 +1,134 @@
+//
+// Created for in-app language switching.
+//
+
+import UIKit
+
+/// Full-screen language picker presented from the Settings screen, mirroring the Android app's
+/// `LanguagePickerDialogFragment`: a rounded card listing every `LanguageOption` with a flag,
+/// a checkmark on the current selection, and a Cancel button.
+final class LanguagePickerViewController: UIViewController, UITableViewDataSource, UITableViewDelegate {
+    private let card = UIView()
+    private let titleLabel = UILabel()
+    private let tableView = UITableView()
+    private let cancelButton = UIButton(type: .system)
+    private let cellReuseIdentifier = "LanguageOptionCell"
+
+    private let options = LocalizationManager.options
+    private let selectedTag = LocalizationManager.currentTag
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        modalPresentationStyle = .overFullScreen
+        modalTransitionStyle = .crossDissolve
+        view.backgroundColor = UIColor.black.withAlphaComponent(0.4)
+
+        setupCard()
+        setupTitleLabel()
+        setupTableView()
+        setupCancelButton()
+    }
+
+    private func setupCard() {
+        card.backgroundColor = Colors.bdColor ?? .white
+        card.layer.cornerRadius = 12
+        card.clipsToBounds = true
+        card.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(card)
+
+        NSLayoutConstraint.activate([
+            card.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 24),
+            card.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -24),
+            card.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+        ])
+    }
+
+    private func setupTitleLabel() {
+        titleLabel.text = Strings.language
+        titleLabel.textColor = Colors.border
+        titleLabel.font = UIFont.boldSystemFont(ofSize: 18)
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        card.addSubview(titleLabel)
+
+        NSLayoutConstraint.activate([
+            titleLabel.topAnchor.constraint(equalTo: card.topAnchor, constant: 16),
+            titleLabel.leadingAnchor.constraint(equalTo: card.leadingAnchor, constant: 16),
+            titleLabel.trailingAnchor.constraint(equalTo: card.trailingAnchor, constant: -16),
+        ])
+    }
+
+    private func setupTableView() {
+        tableView.dataSource = self
+        tableView.delegate = self
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: cellReuseIdentifier)
+        tableView.rowHeight = 52
+        tableView.isScrollEnabled = false
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        card.addSubview(tableView)
+
+        // The table has no intrinsic content size on its own, so its height must be pinned
+        // explicitly -- otherwise Auto Layout collapses it to zero and no rows are visible.
+        let contentHeight = tableView.rowHeight * CGFloat(options.count)
+        let maxHeight = UIScreen.main.bounds.height * 0.5
+        let tableHeight = min(contentHeight, maxHeight)
+        tableView.isScrollEnabled = contentHeight > maxHeight
+
+        NSLayoutConstraint.activate([
+            tableView.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 8),
+            tableView.leadingAnchor.constraint(equalTo: card.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: card.trailingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: card.bottomAnchor),
+            tableView.heightAnchor.constraint(equalToConstant: tableHeight),
+        ])
+    }
+
+    private func setupCancelButton() {
+        cancelButton.setTitle(Strings.cancel, for: .normal)
+        cancelButton.setTitleColor(.white, for: .normal)
+        cancelButton.titleLabel?.font = UIFont.boldSystemFont(ofSize: 16)
+        cancelButton.backgroundColor = .black
+        cancelButton.layer.cornerRadius = 8
+        cancelButton.addTarget(self, action: #selector(cancelTapped), for: .touchUpInside)
+        cancelButton.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(cancelButton)
+
+        NSLayoutConstraint.activate([
+            cancelButton.topAnchor.constraint(equalTo: card.bottomAnchor, constant: 16),
+            cancelButton.leadingAnchor.constraint(equalTo: card.leadingAnchor),
+            cancelButton.trailingAnchor.constraint(equalTo: card.trailingAnchor),
+            cancelButton.heightAnchor.constraint(equalToConstant: 44),
+        ])
+    }
+
+    @objc private func cancelTapped() {
+        dismiss(animated: true)
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        options.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: cellReuseIdentifier, for: indexPath)
+        let option = options[indexPath.row]
+        cell.textLabel?.text = "\(option.flagEmoji)  \(option.displayName)"
+        cell.textLabel?.textColor = Colors.border
+        cell.accessoryType = option.tag == selectedTag ? .checkmark : .none
+        cell.selectionStyle = .default
+        return cell
+    }
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        let option = options[indexPath.row]
+        // Let the picker fully dismiss before starting the transition, otherwise the two
+        // presentations race each other.
+        dismiss(animated: true) {
+            if let presenter = UIApplication.shared.connectedScenes
+                .compactMap({ ($0 as? UIWindowScene)?.keyWindow })
+                .first?.rootViewController {
+                LocalizationManager.apply(tag: option.tag, from: presenter)
+            }
+        }
+    }
+}

--- a/ios/OpenBot/OpenBot/Controllers/Settings/LanguagePickerViewController.swift
+++ b/ios/OpenBot/OpenBot/Controllers/Settings/LanguagePickerViewController.swift
@@ -84,9 +84,9 @@ final class LanguagePickerViewController: UIViewController, UITableViewDataSourc
 
     private func setupCancelButton() {
         cancelButton.setTitle(Strings.cancel, for: .normal)
-        cancelButton.setTitleColor(.white, for: .normal)
+        cancelButton.setTitleColor(.label, for: .normal)
         cancelButton.titleLabel?.font = UIFont.boldSystemFont(ofSize: 16)
-        cancelButton.backgroundColor = .black
+        cancelButton.backgroundColor = .systemGray4
         cancelButton.layer.cornerRadius = 8
         cancelButton.addTarget(self, action: #selector(cancelTapped), for: .touchUpInside)
         cancelButton.translatesAutoresizingMaskIntoConstraints = false
@@ -113,6 +113,7 @@ final class LanguagePickerViewController: UIViewController, UITableViewDataSourc
         let option = options[indexPath.row]
         cell.textLabel?.text = "\(option.flagEmoji)  \(option.displayName)"
         cell.textLabel?.textColor = Colors.border
+        cell.tintColor = .white
         cell.accessoryType = option.tag == selectedTag ? .checkmark : .none
         cell.selectionStyle = .default
         return cell

--- a/ios/OpenBot/OpenBot/Controllers/Settings/SettingsFragment.swift
+++ b/ios/OpenBot/OpenBot/Controllers/Settings/SettingsFragment.swift
@@ -50,6 +50,11 @@ class SettingsFragment: UIViewController, CLLocationManagerDelegate, UITextField
         scrollView.addSubview(createLabel(text: Strings.webSignalingServer, leadingAnchor: 40, topAnchor: adapted(dimensionSize: 350, to: .height)))
         createWebSignalingServerField()
         updateSwitchPosition()
+        registerKeyboardNotifications()
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
     }
 
     /// Called when the view controller's view's size is changed by its parent (i.e. for the root view controller when its window rotates or is resized).
@@ -213,6 +218,34 @@ class SettingsFragment: UIViewController, CLLocationManagerDelegate, UITextField
     func textFieldDidEndEditing(_ textField: UITextField) {
         guard textField == webSignalingServerField, let text = textField.text, !text.isEmpty else { return }
         sharedPreferences.setWebSignalingServerUrl(value: text)
+    }
+
+    /// dismisses the keyboard when the user taps return
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.resignFirstResponder()
+        return true
+    }
+
+    /// listens for the keyboard so the scroll view can be nudged out of its way
+    func registerKeyboardNotifications() {
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow(_:)), name: UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide(_:)), name: UIResponder.keyboardWillHideNotification, object: nil)
+    }
+
+    /// pushes the scroll view's bottom inset up by the keyboard's height and scrolls the field into view
+    @objc func keyboardWillShow(_ notification: Notification) {
+        guard let userInfo = notification.userInfo,
+              let keyboardFrame = (userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue else { return }
+        let keyboardHeight = scrollView.convert(keyboardFrame, from: nil).height
+        scrollView.contentInset.bottom = keyboardHeight
+        scrollView.scrollIndicatorInsets.bottom = keyboardHeight
+        scrollView.scrollRectToVisible(webSignalingServerField.frame.insetBy(dx: 0, dy: -20), animated: true)
+    }
+
+    /// restores the scroll view's original insets once the keyboard is dismissed
+    @objc func keyboardWillHide(_ notification: Notification) {
+        scrollView.contentInset.bottom = 0
+        scrollView.scrollIndicatorInsets.bottom = 0
     }
 
     /// function to set the positions of the buttons.

--- a/ios/OpenBot/OpenBot/Controllers/Settings/SettingsFragment.swift
+++ b/ios/OpenBot/OpenBot/Controllers/Settings/SettingsFragment.swift
@@ -44,7 +44,7 @@ class SettingsFragment: UIViewController, CLLocationManagerDelegate {
         createPermissionIcon(systemName: "mic.fill", topAnchor: adapted(dimensionSize: 250, to: .height))
         scrollView.addSubview(createLabel(text: Strings.bluetooth, leadingAnchor: 40, topAnchor: adapted(dimensionSize: 300, to: .height)))
         createBluetoothSwitch()
-        createPermissionIcon(systemName: "wave.3.right", topAnchor: adapted(dimensionSize: 300, to: .height))
+        createPermissionIcon(image: Images.bluetooth, tinted: false, topAnchor: adapted(dimensionSize: 300, to: .height))
         updateSwitchPosition()
     }
 
@@ -141,8 +141,15 @@ class SettingsFragment: UIViewController, CLLocationManagerDelegate {
 
     /// Creates the SF Symbol icon shown to the left of a permission's switch.
     func createPermissionIcon(systemName: String, topAnchor: CGFloat) {
-        let icon = UIImageView(image: UIImage(systemName: systemName))
-        icon.tintColor = Colors.border
+        createPermissionIcon(image: UIImage(systemName: systemName), tinted: true, topAnchor: topAnchor)
+    }
+
+    /// Creates a permission row icon from a bundled image asset
+    func createPermissionIcon(image: UIImage?, tinted: Bool, topAnchor: CGFloat) {
+        let icon = UIImageView(image: image)
+        if tinted {
+            icon.tintColor = Colors.border
+        }
         icon.contentMode = .scaleAspectFit
         icon.frame = CGRect(x: switchButtonTrailingAnchor - 40, y: topAnchor + 8, width: 24, height: 24)
         scrollView.addSubview(icon)

--- a/ios/OpenBot/OpenBot/Controllers/Settings/SettingsFragment.swift
+++ b/ios/OpenBot/OpenBot/Controllers/Settings/SettingsFragment.swift
@@ -85,6 +85,7 @@ class SettingsFragment: UIViewController, CLLocationManagerDelegate {
     func createSectionHeader(text: String, topAnchor: CGFloat) -> UILabel {
         let header = createLabel(text: text, leadingAnchor: 20, topAnchor: topAnchor)
         header.font = UIFont.boldSystemFont(ofSize: 20.0)
+        header.frame.size.width = measuredWidth(of: text, font: header.font) + 8
         return header
     }
 

--- a/ios/OpenBot/OpenBot/Controllers/Settings/SettingsFragment.swift
+++ b/ios/OpenBot/OpenBot/Controllers/Settings/SettingsFragment.swift
@@ -47,7 +47,7 @@ class SettingsFragment: UIViewController, CLLocationManagerDelegate, UITextField
         scrollView.addSubview(createLabel(text: Strings.bluetooth, leadingAnchor: 40, topAnchor: adapted(dimensionSize: 300, to: .height)))
         createBluetoothSwitch()
         createPermissionIcon(image: Images.bluetooth, tinted: false, topAnchor: adapted(dimensionSize: 300, to: .height))
-        scrollView.addSubview(createLabel(text: Strings.webSignalingServer, leadingAnchor: 40, topAnchor: adapted(dimensionSize: 250, to: .height)))
+        scrollView.addSubview(createLabel(text: Strings.webSignalingServer, leadingAnchor: 40, topAnchor: adapted(dimensionSize: 350, to: .height)))
         createWebSignalingServerField()
         updateSwitchPosition()
     }
@@ -205,7 +205,7 @@ class SettingsFragment: UIViewController, CLLocationManagerDelegate, UITextField
         webSignalingServerField.autocapitalizationType = .none
         webSignalingServerField.autocorrectionType = .no
         webSignalingServerField.delegate = self
-        webSignalingServerField.frame = CGRect(x: 40, y: adapted(dimensionSize: 280, to: .height), width: width - 80, height: 40)
+        webSignalingServerField.frame = CGRect(x: 40, y: adapted(dimensionSize: 380, to: .height), width: width - 80, height: 40)
         scrollView.addSubview(webSignalingServerField)
     }
 

--- a/ios/OpenBot/OpenBot/Controllers/Settings/SettingsFragment.swift
+++ b/ios/OpenBot/OpenBot/Controllers/Settings/SettingsFragment.swift
@@ -17,22 +17,34 @@ class SettingsFragment: UIViewController, CLLocationManagerDelegate {
     let bluetoothSwitch = UISwitch()
     var switchButtonTrailingAnchor = width - 80;
     let locationManager = CLLocationManager()
+    /// Kept alive only long enough to trigger CoreBluetooth's system permission prompt on first ask.
+    var bluetoothPermissionProbe: CBCentralManager?
+    let flagLabel = UILabel()
 
     /// Called after the view fragment has loaded.
     override func viewDidLoad() {
         super.viewDidLoad()
+        locationManager.delegate = self
         createScrollView()
-        createPermissionLabel()
-        setupSwitchPositions()
         scrollView.contentSize = CGSize(width: width, height: height)
-        scrollView.addSubview(createLabel(text: Strings.camera, leadingAnchor: 40, topAnchor: adapted(dimensionSize: 50, to: .height)))
+
+        scrollView.addSubview(createSectionHeader(text: Strings.general, topAnchor: adapted(dimensionSize: 10, to: .height)))
+        createLanguageRow()
+
+        scrollView.addSubview(createSectionHeader(text: Strings.permission, topAnchor: adapted(dimensionSize: 110, to: .height)))
+        setupSwitchPositions()
+        scrollView.addSubview(createLabel(text: Strings.camera, leadingAnchor: 40, topAnchor: adapted(dimensionSize: 150, to: .height)))
         createCameraSwitch()
-        scrollView.addSubview(createLabel(text: Strings.location, leadingAnchor: 40, topAnchor: adapted(dimensionSize: 100, to: .height)))
+        createPermissionIcon(systemName: "camera.fill", topAnchor: adapted(dimensionSize: 150, to: .height))
+        scrollView.addSubview(createLabel(text: Strings.location, leadingAnchor: 40, topAnchor: adapted(dimensionSize: 200, to: .height)))
         createLocationSwitch()
-        scrollView.addSubview(createLabel(text: Strings.microphone, leadingAnchor: 40, topAnchor: adapted(dimensionSize: 150, to: .height)))
+        createPermissionIcon(systemName: "location.fill", topAnchor: adapted(dimensionSize: 200, to: .height))
+        scrollView.addSubview(createLabel(text: Strings.microphone, leadingAnchor: 40, topAnchor: adapted(dimensionSize: 250, to: .height)))
         createMicrophoneSwitch()
-        scrollView.addSubview(createLabel(text: Strings.bluetooth, leadingAnchor: 40, topAnchor: adapted(dimensionSize: 200, to: .height)))
+        createPermissionIcon(systemName: "mic.fill", topAnchor: adapted(dimensionSize: 250, to: .height))
+        scrollView.addSubview(createLabel(text: Strings.bluetooth, leadingAnchor: 40, topAnchor: adapted(dimensionSize: 300, to: .height)))
         createBluetoothSwitch()
+        createPermissionIcon(systemName: "wave.3.right", topAnchor: adapted(dimensionSize: 300, to: .height))
         updateSwitchPosition()
     }
 
@@ -48,7 +60,7 @@ class SettingsFragment: UIViewController, CLLocationManagerDelegate {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         toggleSwitchButtons()
-
+        flagLabel.text = LocalizationManager.currentFlagEmoji
     }
 
     /// Creates a new scroll view with dimensions equal to the main screen size.
@@ -69,11 +81,49 @@ class SettingsFragment: UIViewController, CLLocationManagerDelegate {
         }
     }
 
-    /// Creates a label for permissions Heading.
-    func createPermissionLabel() {
-        let permission = createLabel(text: Strings.permission, leadingAnchor: 40, topAnchor: adapted(dimensionSize: 10, to: .height));
-        permission.font = UIFont.systemFont(ofSize: 17.0)
-        scrollView.addSubview(permission);
+    /// Creates a bold section header label (e.g. "General", "Permissions").
+    func createSectionHeader(text: String, topAnchor: CGFloat) -> UILabel {
+        let header = createLabel(text: text, leadingAnchor: 20, topAnchor: topAnchor)
+        header.font = UIFont.boldSystemFont(ofSize: 20.0)
+        return header
+    }
+
+    /// Creates the tappable "Language" row: title + subtitle on the left, current flag on the right.
+    func createLanguageRow() {
+        let rowTop = adapted(dimensionSize: 50, to: .height)
+        // Leaves room for the flag on the right; wraps instead of relying on a measured single-line
+        // width, since translated title/subtitle text varies too much in length to assume one line.
+        let textWidth = width - 40 - 90
+
+        let title = UILabel()
+        title.text = Strings.language
+        title.textColor = Colors.border
+        title.font = UIFont.systemFont(ofSize: 17.0)
+        title.numberOfLines = 1
+        title.frame = CGRect(x: 40, y: rowTop, width: textWidth, height: 22)
+        scrollView.addSubview(title)
+
+        let subtitle = UILabel()
+        subtitle.text = Strings.languageSubtitle
+        subtitle.textColor = Colors.textColor
+        subtitle.font = UIFont.systemFont(ofSize: 13.0)
+        subtitle.numberOfLines = 2
+        subtitle.frame = CGRect(x: 40, y: rowTop + 22, width: textWidth, height: 32)
+        scrollView.addSubview(subtitle)
+
+        flagLabel.text = LocalizationManager.currentFlagEmoji
+        flagLabel.font = UIFont.systemFont(ofSize: 24.0)
+        flagLabel.frame = CGRect(x: width - 70, y: rowTop, width: 40, height: 40)
+        scrollView.addSubview(flagLabel)
+
+        let tapArea = UIView(frame: CGRect(x: 0, y: rowTop - 10, width: width, height: 70))
+        tapArea.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(openLanguagePicker)))
+        scrollView.addSubview(tapArea)
+    }
+
+    @objc func openLanguagePicker() {
+        let picker = LanguagePickerViewController()
+        present(picker, animated: true)
     }
 
     /// Creates a new label with the given text, leading anchor, and top anchor.
@@ -83,9 +133,18 @@ class SettingsFragment: UIViewController, CLLocationManagerDelegate {
         label.textColor = Colors.border
         label.font = UIFont.systemFont(ofSize: 15.0)
         label.frame.origin = CGPoint(x: leadingAnchor, y: topAnchor)
-        label.frame.size = resized(size: CGSize(width: text.count * 12, height: 40), basedOn: .height)
+        label.frame.size = resized(size: CGSize(width: measuredWidth(of: text, font: label.font) + 8, height: 40), basedOn: .height)
         return label;
 
+    }
+
+    /// Creates the SF Symbol icon shown to the left of a permission's switch.
+    func createPermissionIcon(systemName: String, topAnchor: CGFloat) {
+        let icon = UIImageView(image: UIImage(systemName: systemName))
+        icon.tintColor = Colors.border
+        icon.contentMode = .scaleAspectFit
+        icon.frame = CGRect(x: switchButtonTrailingAnchor - 40, y: topAnchor + 8, width: 24, height: 24)
+        scrollView.addSubview(icon)
     }
 
     /// Creates a new switch button.
@@ -98,7 +157,7 @@ class SettingsFragment: UIViewController, CLLocationManagerDelegate {
     func createCameraSwitch() {
         cameraSwitch.onTintColor = Colors.title
         scrollView.addSubview(cameraSwitch)
-        cameraSwitch.frame.origin = CGPoint(x: width - 80, y: adapted(dimensionSize: 50, to: .height))
+        cameraSwitch.frame.origin = CGPoint(x: width - 80, y: adapted(dimensionSize: 150, to: .height))
         cameraSwitch.addTarget(self, action: #selector(toggleCamera(_:)), for: .valueChanged)
     }
 
@@ -106,7 +165,7 @@ class SettingsFragment: UIViewController, CLLocationManagerDelegate {
     func createLocationSwitch() {
         locationSwitch.onTintColor = Colors.title
         scrollView.addSubview(locationSwitch)
-        locationSwitch.frame.origin = CGPoint(x: width - 80, y: adapted(dimensionSize: 100, to: .height))
+        locationSwitch.frame.origin = CGPoint(x: width - 80, y: adapted(dimensionSize: 200, to: .height))
         locationSwitch.addTarget(self, action: #selector(toggleLocation(_:)), for: .valueChanged)
     }
 
@@ -114,7 +173,7 @@ class SettingsFragment: UIViewController, CLLocationManagerDelegate {
     func createMicrophoneSwitch() {
         microphoneSwitch.onTintColor = Colors.title
         scrollView.addSubview(microphoneSwitch)
-        microphoneSwitch.frame.origin = CGPoint(x: width - 80, y: adapted(dimensionSize: 150, to: .height))
+        microphoneSwitch.frame.origin = CGPoint(x: width - 80, y: adapted(dimensionSize: 250, to: .height))
         microphoneSwitch.addTarget(self, action: #selector(toggleMicrophone(_:)), for: .valueChanged)
     }
 
@@ -122,7 +181,7 @@ class SettingsFragment: UIViewController, CLLocationManagerDelegate {
     func createBluetoothSwitch() {
         bluetoothSwitch.onTintColor = Colors.title
         scrollView.addSubview(bluetoothSwitch)
-        bluetoothSwitch.frame.origin = CGPoint(x: width - 80, y: adapted(dimensionSize: 200, to: .height))
+        bluetoothSwitch.frame.origin = CGPoint(x: width - 80, y: adapted(dimensionSize: 300, to: .height))
         bluetoothSwitch.addTarget(self, action: #selector(toggleBluetooth(_:)), for: .valueChanged)
     }
 
@@ -177,9 +236,9 @@ class SettingsFragment: UIViewController, CLLocationManagerDelegate {
         let authStatus = AVCaptureDevice.authorizationStatus(for: AVMediaType.video)
         switch authStatus {
         case .authorized:
-            createAllowAlert(alertFor: "Camera")
+            createAllowAlert(alertFor: Strings.camera)
         case .denied:
-            createAllowAlert(alertFor: "Camera")
+            createAllowAlert(alertFor: Strings.camera)
         case .notDetermined:
             createPromptForCameraAccess()
         default:
@@ -187,30 +246,60 @@ class SettingsFragment: UIViewController, CLLocationManagerDelegate {
         }
     }
 
-    /// function to check whether location is allowed or not.
+    /// function to check whether location is allowed or not, requesting it directly the first time it's asked.
     func checkLocation() {
-        createAllowAlert(alertFor: "Location")
+        var authStatus: CLAuthorizationStatus
+        if #available(iOS 14.0, *) {
+            authStatus = locationManager.authorizationStatus
+        } else {
+            authStatus = CLLocationManager.authorizationStatus()
+        }
+        switch authStatus {
+        case .notDetermined:
+            locationManager.requestWhenInUseAuthorization()
+        default:
+            createAllowAlert(alertFor: Strings.location)
+        }
     }
 
-    /// function to check whether microphone is allowed or not
+    /// function to check whether microphone is allowed or not, requesting it directly the first time it's asked.
     func checkMicrophone() {
-        createAllowAlert(alertFor: "Microphone")
+        switch AVAudioSession.sharedInstance().recordPermission {
+        case .undetermined:
+            AVAudioSession.sharedInstance().requestRecordPermission { _ in
+                DispatchQueue.main.async {
+                    self.toggleSwitchButtons()
+                }
+            }
+        default:
+            createAllowAlert(alertFor: Strings.microphone)
+        }
     }
 
-    ///function to check whether bluetooth is allowed or not
+    ///function to check whether bluetooth is allowed or not, requesting it directly the first time it's asked.
     func checkBluetooth() {
-        createAllowAlert(alertFor: "Bluetooth")
+        switch CBCentralManager.authorization {
+        case .notDetermined:
+            // Instantiating a CBCentralManager triggers CoreBluetooth's system permission prompt.
+            bluetoothPermissionProbe = CBCentralManager()
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                self.toggleSwitchButtons()
+                self.bluetoothPermissionProbe = nil
+            }
+        default:
+            createAllowAlert(alertFor: Strings.bluetooth)
+        }
     }
 
     /// function to show the camera alert on the screen.
     func alertToEncourageCameraAccessInitially() {
         let alert = UIAlertController(
-                title: "IMPORTANT",
-                message: "Camera access required for OpenBot",
+                title: Strings.important,
+                message: Strings.cameraAccessRequiredMessage,
                 preferredStyle: UIAlertController.Style.alert
         )
-        alert.addAction(UIAlertAction(title: "Cancel", style: .default, handler: { action in print(action) }))
-        alert.addAction(UIAlertAction(title: "Allow Camera", style: .cancel, handler: { (alert) -> Void in
+        alert.addAction(UIAlertAction(title: Strings.cancel, style: .default, handler: { action in print(action) }))
+        alert.addAction(UIAlertAction(title: String(format: Strings.allowButtonFormat, Strings.camera), style: .cancel, handler: { (alert) -> Void in
             guard let url = URL(string: UIApplication.openSettingsURLString), !url.absoluteString.isEmpty else {
                 return
             }
@@ -234,12 +323,12 @@ class SettingsFragment: UIViewController, CLLocationManagerDelegate {
     /// function to create prompts for settings
     func createAllowAlert(alertFor: String) {
         let alert = UIAlertController(
-                title: "IMPORTANT",
-                message: "Please allow " + alertFor + " access for OpenBot",
+                title: Strings.important,
+                message: String(format: Strings.allowPermissionMessageFormat, alertFor),
                 preferredStyle: UIAlertController.Style.alert
         )
-        alert.addAction(UIAlertAction(title: "Cancel", style: .default, handler: { action in self.toggleSwitchButtons() }))
-        alert.addAction(UIAlertAction(title: "Allow " + alertFor, style: .cancel, handler: { (alert) -> Void in
+        alert.addAction(UIAlertAction(title: Strings.cancel, style: .default, handler: { action in self.toggleSwitchButtons() }))
+        alert.addAction(UIAlertAction(title: String(format: Strings.allowButtonFormat, alertFor), style: .cancel, handler: { (alert) -> Void in
             guard let url = URL(string: UIApplication.openSettingsURLString), !url.absoluteString.isEmpty else {
                 return
             }

--- a/ios/OpenBot/OpenBot/Controllers/WebView/WebViewFragment.swift
+++ b/ios/OpenBot/OpenBot/Controllers/WebView/WebViewFragment.swift
@@ -135,7 +135,7 @@ class openCodeWebView: UIViewController, WKUIDelegate, WKNavigationDelegate {
             textField.text = defaultText
         }
 
-        alertController.addAction(UIAlertAction(title: "OK", style: .default, handler: { (action) in
+        alertController.addAction(UIAlertAction(title: Strings.okAction, style: .default, handler: { (action) in
             if let text = alertController.textFields?.first?.text {
                 completionHandler(text)
             } else {
@@ -143,7 +143,7 @@ class openCodeWebView: UIViewController, WKUIDelegate, WKNavigationDelegate {
             }
         }))
 
-        alertController.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: { (action) in
+        alertController.addAction(UIAlertAction(title: Strings.cancel, style: .cancel, handler: { (action) in
             completionHandler(nil)
         }))
 

--- a/ios/OpenBot/OpenBot/Controllers/runRobot/RunRobot.swift
+++ b/ios/OpenBot/OpenBot/Controllers/runRobot/RunRobot.swift
@@ -67,11 +67,11 @@ class runRobot: CameraController, ARSCNViewDelegate, UITextFieldDelegate {
         super.viewDidLoad()
         setUpUI();
         stopRobot.backgroundColor = Colors.title;
-        stopRobot.setTitle("Stop Robot", for: .normal);
+        stopRobot.setTitle(Strings.stopRobotButton, for: .normal);
         stopRobot.addTarget(self, action: #selector(cancel), for: .touchUpInside);
         stopRobot.layer.cornerRadius = 10;
         resetRobot.backgroundColor = Colors.title
-        resetRobot.setTitle("Reset Robot", for: .normal);
+        resetRobot.setTitle(Strings.resetRobotButton, for: .normal);
         resetRobot.addTarget(self, action: #selector(resetRobotFunction), for: .touchUpInside);
         resetRobot.layer.cornerRadius = 10;
         NotificationCenter.default.addObserver(self, selector: #selector(updateCommandMsg), name: .commandName, object: nil);
@@ -369,9 +369,9 @@ class runRobot: CameraController, ARSCNViewDelegate, UITextFieldDelegate {
      */
     @objc func cancel() {
         NotificationCenter.default.post(name: .cancelThread, object: nil);
-        NotificationCenter.default.post(name: .commandName, object: "\(Strings.cancel)ed");
+        NotificationCenter.default.post(name: .commandName, object: Strings.cancelledStatus);
         stopCar();
-        self.stopRobot.setTitle("Back", for: .normal);
+        self.stopRobot.setTitle(Strings.back, for: .normal);
         self.stopRobot.removeTarget(nil, action: nil, for: .touchUpInside)
         self.stopRobot.addTarget(self, action: #selector(self.backItem(sender:)), for: .touchUpInside);
     }
@@ -382,7 +382,7 @@ class runRobot: CameraController, ARSCNViewDelegate, UITextFieldDelegate {
     @objc  func resetRobotFunction() {
             self.stopCar()
             _ = jsEvaluator(jsCode: self.preferencesManager.getBlocklyCode()!);
-            self.stopRobot.setTitle("Stop Car", for: .normal);
+            self.stopRobot.setTitle(Strings.stopCarButton, for: .normal);
             self.stopRobot.removeTarget(nil, action: nil, for: .touchUpInside)
             self.stopRobot.addTarget(self, action: #selector(self.cancel), for: .touchUpInside);
     }
@@ -393,7 +393,7 @@ class runRobot: CameraController, ARSCNViewDelegate, UITextFieldDelegate {
     func setupNavigationBarItem() {
         if UIImage(named: "back") != nil {
             let backNavigationIcon = (UIImage(named: "back")?.withRenderingMode(.alwaysOriginal))!
-            let newBackButton = UIBarButtonItem(image: backNavigationIcon, title: "Playground", target: self, action: #selector(back(sender:)), titleColor: Colors.navigationColor ?? .white)
+            let newBackButton = UIBarButtonItem(image: backNavigationIcon, title: Strings.playgroundNavTitle, target: self, action: #selector(back(sender:)), titleColor: Colors.navigationColor ?? .white)
             navigationItem.leftBarButtonItem = newBackButton
         }
     }

--- a/ios/OpenBot/OpenBot/Controllers/runRobot/RunRobot.swift
+++ b/ios/OpenBot/OpenBot/Controllers/runRobot/RunRobot.swift
@@ -159,7 +159,7 @@ class runRobot: CameraController, ARSCNViewDelegate, UITextFieldDelegate {
      function to create label
      */
     func setUpLabel(){
-        commandMessage.text = "You code is executing..";
+        commandMessage.text = Strings.codeExecuting;
         commandMessage.translatesAutoresizingMaskIntoConstraints = false;
         if currentOrientation == .portrait {
             topLabelConstraint = commandMessage.topAnchor.constraint(equalTo: view.topAnchor, constant: 450)

--- a/ios/OpenBot/OpenBot/Info.plist
+++ b/ios/OpenBot/OpenBot/Info.plist
@@ -20,6 +20,16 @@
 	<dict/>
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
+	<key>CFBundleLocalizations</key>
+	<array>
+		<string>en</string>
+		<string>de</string>
+		<string>es</string>
+		<string>fr</string>
+		<string>zh-Hans</string>
+		<string>ko</string>
+		<string>hi</string>
+	</array>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/ios/OpenBot/OpenBot/SceneDelegate.swift
+++ b/ios/OpenBot/OpenBot/SceneDelegate.swift
@@ -14,6 +14,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
     // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
     guard let window = (scene as? UIWindowScene) else { return }
+    if let rootViewController = window.windows.first?.rootViewController {
+        LocalizationManager.refreshTabBarTitles(in: rootViewController)
+    }
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {

--- a/ios/OpenBot/OpenBot/Storyboards/openCode.storyboard
+++ b/ios/OpenBot/OpenBot/Storyboards/openCode.storyboard
@@ -147,6 +147,9 @@
                     </view>
                     <connections>
                         <outlet property="confirmLogoutLabel" destination="p7T-Sc-pYT" id="tiV-kt-4Gt"/>
+                        <outlet property="confirmLogoutMessageLabel" destination="BhB-vU-Jms" id="Lcl-03-msgL"/>
+                        <outlet property="cancelButton" destination="cBx-4m-rvF" id="Lcl-01-canB"/>
+                        <outlet property="logOutButton" destination="ddC-HJ-0x5" id="Lcl-02-logB"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="yAW-td-qNf" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/ios/OpenBot/OpenBot/Utils/Adaptive/AdaptiveLayoutHelper.swift
+++ b/ios/OpenBot/OpenBot/Utils/Adaptive/AdaptiveLayoutHelper.swift
@@ -38,6 +38,11 @@ func resized(size: CGSize, basedOn dimension: Dimension) -> CGSize {
     return CGSize(width: width, height: height)
 }
 
+/// Measures the real rendered width of `text` at `font`
+func measuredWidth(of text: String, font: UIFont) -> CGFloat {
+    ceil((text as NSString).size(withAttributes: [.font: font]).width)
+}
+
 /// This function allows finetuning a reference dimension to match the user interface screen
 ///
 /// - Parameters:

--- a/ios/OpenBot/OpenBot/Utils/Constants.swift
+++ b/ios/OpenBot/OpenBot/Utils/Constants.swift
@@ -79,24 +79,26 @@ struct Constants {
     static let openbotService_TX = "9bf1103b-834c-47cf-b149-c9e4bcf778a7"
 
     // Game Data
-    static let gameModes: [[ModeItem]] = [
-        // General
+    static var gameModes: [[ModeItem]] {
         [
-            ModeItem(label: Strings.freeRoam, icon: Images.freeRoam!, identifier: Strings.ScreenFreeRoam, color: Colors.freeRoamColor),
-            ModeItem(label: Strings.dataCollection, icon: Images.dataCollection!, identifier: Strings.ScreenDataCollection, color: Colors.dataCollectionColor),
-            ModeItem(label: Strings.controllerMapping, icon: Images.controllerMapping!, identifier: Strings.ScreenControllerMapping, color: Colors.controllerMappingColor),
-            ModeItem(label: Strings.robotInfo, icon: Images.robotInfoIcon!, identifier: Strings.ScreenRobotInfo, color: Colors.robotInfoColor),
-        ],
-        // AI
-        [
-            ModeItem(label: Strings.Autopilot, icon: Images.autopilotIcon!, identifier: Strings.AutopilotFragment, color: Colors.autopilotColor),
-            ModeItem(label: Strings.ObjectTracking, icon: Images.objectTrackingIcon!, identifier: Strings.ObjectTrackingFragment, color: Colors.objectTrackingColor),
-            ModeItem(label: Strings.navigation, icon: Images.pointGoalIcon!, identifier: Strings.ScreenNavigation, color: Colors.pointGoalColor),
-            ModeItem(label: Strings.modelManagement, icon: Images.modelManagementIcon!, identifier: Strings.ScreenModelManagement, color: Colors.modelColor)
-        ],
-        // Legacy
-        []
-    ]
+            // General
+            [
+                ModeItem(label: Strings.freeRoam, icon: Images.freeRoam!, identifier: Strings.ScreenFreeRoam, color: Colors.freeRoamColor),
+                ModeItem(label: Strings.dataCollection, icon: Images.dataCollection!, identifier: Strings.ScreenDataCollection, color: Colors.dataCollectionColor),
+                ModeItem(label: Strings.controllerMapping, icon: Images.controllerMapping!, identifier: Strings.ScreenControllerMapping, color: Colors.controllerMappingColor),
+                ModeItem(label: Strings.robotInfo, icon: Images.robotInfoIcon!, identifier: Strings.ScreenRobotInfo, color: Colors.robotInfoColor),
+            ],
+            // AI
+            [
+                ModeItem(label: Strings.Autopilot, icon: Images.autopilotIcon!, identifier: Strings.AutopilotFragment, color: Colors.autopilotColor),
+                ModeItem(label: Strings.ObjectTracking, icon: Images.objectTrackingIcon!, identifier: Strings.ObjectTrackingFragment, color: Colors.objectTrackingColor),
+                ModeItem(label: Strings.navigation, icon: Images.pointGoalIcon!, identifier: Strings.ScreenNavigation, color: Colors.pointGoalColor),
+                ModeItem(label: Strings.modelManagement, icon: Images.modelManagementIcon!, identifier: Strings.ScreenModelManagement, color: Colors.modelColor)
+            ],
+            // Legacy
+            []
+        ]
+    }
     static let frameColors: [UIColor] = [UIColor.red, UIColor.orange, UIColor.blue, UIColor.green, UIColor.brown]
     static let autopilotMode = "AUTOPILOT"
     static let objectTrackingMode = "DETECTOR"

--- a/ios/OpenBot/OpenBot/Utils/GoogleSignInButton.swift
+++ b/ios/OpenBot/OpenBot/Utils/GoogleSignInButton.swift
@@ -29,8 +29,17 @@ class GoogleSignInBtn : UIView {
     func createSignInBtn(frame: CGRect) {
         self.backgroundColor = UIColor(named: "signInButtonColor");
         layer.cornerRadius = 10;
-        addSubview(createGoogleIcon(frame: CGRect(x: self.frame.width / 2 - 100, y: 16, width: 20, height: 20)));
-        addSubview(createSingInText(frame: CGRect(x: self.frame.width / 2 - 69, y: 5, width: 160, height: 40)))
+        // Icon + text are centered as a group based on the text's real measured width, since a
+        // fixed offset/width tuned for the English string leaves other languages off-center or
+        // truncated (translations vary a lot in length).
+        let font = UIFont.systemFont(ofSize: 18)
+        let textWidth = measuredWidth(of: Strings.signInWithGoogle, font: font)
+        let iconWidth: CGFloat = 20
+        let spacing: CGFloat = 12
+        let groupWidth = iconWidth + spacing + textWidth
+        let groupStartX = (self.frame.width - groupWidth) / 2
+        addSubview(createGoogleIcon(frame: CGRect(x: groupStartX, y: 16, width: iconWidth, height: iconWidth)));
+        addSubview(createSingInText(frame: CGRect(x: groupStartX + iconWidth + spacing, y: 5, width: textWidth + 4, height: 40), font: font))
     }
 
     /**
@@ -49,11 +58,11 @@ class GoogleSignInBtn : UIView {
      - Parameter frame:
      - Returns:
      */
-    private func createSingInText(frame: CGRect) -> UILabel {
+    private func createSingInText(frame: CGRect, font: UIFont) -> UILabel {
         let signInText = UILabel(frame: frame);
-        signInText.text = "Sign-in with Google";
+        signInText.text = Strings.signInWithGoogle;
         signInText.textColor = traitCollection.userInterfaceStyle == .dark ? UIColor.white : UIColor.black
-        signInText.font = signInText.font?.withSize(18);
+        signInText.font = font;
         return signInText;
     }
 

--- a/ios/OpenBot/OpenBot/Utils/L10n.swift
+++ b/ios/OpenBot/OpenBot/Utils/L10n.swift
@@ -1,0 +1,11 @@
+//
+// Created for in-app language switching.
+//
+
+import Foundation
+
+enum L10n {
+    static func string(_ key: String) -> String {
+        LocalizationManager.bundle.localizedString(forKey: key, value: key, table: nil)
+    }
+}

--- a/ios/OpenBot/OpenBot/Utils/LocalizationManager.swift
+++ b/ios/OpenBot/OpenBot/Utils/LocalizationManager.swift
@@ -1,0 +1,116 @@
+//
+// Created by Hardik Garg on 03/08/26
+//
+
+import UIKit
+
+struct LanguageOption {
+    let tag: String?
+    let displayName: String
+    let flagEmoji: String
+}
+
+/// Supported in-app display languages, resolved into a `Bundle` that `L10n.string(_:)` reads.
+enum LocalizationManager {
+    private static let languageDefaultsKey = "AppLanguageOverride"
+    private static let supportedTags = ["en", "de", "es", "fr", "zh-Hans", "ko", "hi"]
+
+    static var options: [LanguageOption] {
+        [
+            LanguageOption(tag: nil, displayName: Strings.systemDefault, flagEmoji: "🌐"),
+            LanguageOption(tag: "en", displayName: "English", flagEmoji: "🇺🇸"),
+            LanguageOption(tag: "de", displayName: "Deutsch", flagEmoji: "🇩🇪"),
+            LanguageOption(tag: "es", displayName: "Español", flagEmoji: "🇪🇸"),
+            LanguageOption(tag: "fr", displayName: "Français", flagEmoji: "🇫🇷"),
+            LanguageOption(tag: "zh-Hans", displayName: "中文", flagEmoji: "🇨🇳"),
+            LanguageOption(tag: "ko", displayName: "한국어", flagEmoji: "🇰🇷"),
+            LanguageOption(tag: "hi", displayName: "हिन्दी", flagEmoji: "🇮🇳"),
+        ]
+    }
+
+    /// The chosen language tag, or `nil` when following the system language.
+    static var currentTag: String? {
+        get { UserDefaults.standard.string(forKey: languageDefaultsKey) }
+        set {
+            if let newValue = newValue {
+                UserDefaults.standard.set(newValue, forKey: languageDefaultsKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: languageDefaultsKey)
+            }
+        }
+    }
+
+    /// The flag emoji for the currently active language (falls back to the system-default option's).
+    static var currentFlagEmoji: String {
+        options.first(where: { $0.tag == currentTag })?.flagEmoji ?? options[0].flagEmoji
+    }
+
+    /// The bundle every localized string lookup should use: the user's chosen language if set,
+    /// otherwise the best match between the system's preferred languages and what we support.
+    static var bundle: Bundle {
+        let tag = currentTag ?? bestSystemMatch()
+        guard let path = Bundle.main.path(forResource: tag, ofType: "lproj"),
+              let bundle = Bundle(path: path) else {
+            return .main
+        }
+        return bundle
+    }
+
+    private static func bestSystemMatch() -> String {
+        Bundle.preferredLocalizations(from: supportedTags).first ?? "en"
+    }
+
+    /// Applies a newly selected language: persists it, then rebuilds the window's whole view
+    static func apply(tag: String?, from viewController: UIViewController) {
+        currentTag = tag
+
+        guard let window = viewController.view.window else { return }
+
+        let overlay = LanguageApplyingView(frame: window.bounds)
+        overlay.alpha = 0
+        window.addSubview(overlay)
+
+        UIView.animate(withDuration: 0.2, animations: {
+            overlay.alpha = 1
+        }, completion: { _ in
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
+                let newRoot = UIStoryboard(name: "Main", bundle: nil).instantiateInitialViewController()
+                if let newRoot = newRoot {
+                    refreshTabBarTitles(in: newRoot)
+                }
+                window.rootViewController = newRoot
+                UIView.animate(withDuration: 0.3, animations: {
+                    overlay.alpha = 0
+                }, completion: { _ in
+                    overlay.removeFromSuperview()
+                })
+            }
+        })
+    }
+
+    static func refreshTabBarTitles(in root: UIViewController) {
+        guard let tabBarController = findTabBarController(in: root) else { return }
+        for child in tabBarController.viewControllers ?? [] {
+            switch child {
+            case is HomePageViewController:
+                child.tabBarItem.title = Strings.homeTab
+            case is projectFragment:
+                child.tabBarItem.title = Strings.projectsTab
+            case is profileFragment:
+                child.tabBarItem.title = Strings.profileTab
+            default:
+                break
+            }
+        }
+    }
+
+    private static func findTabBarController(in viewController: UIViewController) -> UITabBarController? {
+        if let tabBarController = viewController as? UITabBarController {
+            return tabBarController
+        }
+        if let navigationController = viewController as? UINavigationController {
+            return navigationController.viewControllers.first.flatMap(findTabBarController)
+        }
+        return viewController.children.first.flatMap(findTabBarController)
+    }
+}

--- a/ios/OpenBot/OpenBot/Utils/LocalizationManager.swift
+++ b/ios/OpenBot/OpenBot/Utils/LocalizationManager.swift
@@ -37,6 +37,7 @@ enum LocalizationManager {
             } else {
                 UserDefaults.standard.removeObject(forKey: languageDefaultsKey)
             }
+            cachedBundle = nil
         }
     }
 
@@ -45,15 +46,25 @@ enum LocalizationManager {
         options.first(where: { $0.tag == currentTag })?.flagEmoji ?? options[0].flagEmoji
     }
 
+    private static var cachedBundle: Bundle?
+
     /// The bundle every localized string lookup should use: the user's chosen language if set,
     /// otherwise the best match between the system's preferred languages and what we support.
+    /// Cached until `currentTag` changes, since resolving it hits the file system.
     static var bundle: Bundle {
-        let tag = currentTag ?? bestSystemMatch()
-        guard let path = Bundle.main.path(forResource: tag, ofType: "lproj"),
-              let bundle = Bundle(path: path) else {
-            return .main
+        if let cachedBundle = cachedBundle {
+            return cachedBundle
         }
-        return bundle
+        let tag = currentTag ?? bestSystemMatch()
+        let resolved: Bundle
+        if let path = Bundle.main.path(forResource: tag, ofType: "lproj"),
+           let bundle = Bundle(path: path) {
+            resolved = bundle
+        } else {
+            resolved = .main
+        }
+        cachedBundle = resolved
+        return resolved
     }
 
     private static func bestSystemMatch() -> String {

--- a/ios/OpenBot/OpenBot/Utils/Strings.swift
+++ b/ios/OpenBot/OpenBot/Utils/Strings.swift
@@ -201,6 +201,79 @@ struct Strings {
     static var homeTab: String { L10n.string("homeTab") }
     static var profileTab: String { L10n.string("profileTab") }
 
+    // Loading / generic alerts
+    static var loadingTitle: String { L10n.string("loadingTitle") }
+    static var loadingProfileMessage: String { L10n.string("loadingProfileMessage") }
+    static var loadingDataMessage: String { L10n.string("loadingDataMessage") }
+    static var pleaseWaitMessage: String { L10n.string("pleaseWaitMessage") }
+    static var errorHeading: String { L10n.string("errorHeading") }
+    static var genericErrorMessage: String { L10n.string("genericErrorMessage") }
+    static var okAction: String { L10n.string("okAction") }
+
+    // Profile screen
+    static var myProfileHeading: String { L10n.string("myProfileHeading") }
+    static var setupProfilePromptLine1: String { L10n.string("setupProfilePromptLine1") }
+    static var setupProfilePromptLine2: String { L10n.string("setupProfilePromptLine2") }
+    static var editProfile: String { L10n.string("editProfile") }
+    static var logoutMenuItem: String { L10n.string("logoutMenuItem") }
+    static var firstNameFieldLabel: String { L10n.string("firstNameFieldLabel") }
+    static var lastNameFieldLabel: String { L10n.string("lastNameFieldLabel") }
+    static var dateOfBirthFieldLabel: String { L10n.string("dateOfBirthFieldLabel") }
+    static var emailFieldLabel: String { L10n.string("emailFieldLabel") }
+    static var unknownFallback: String { L10n.string("unknownFallback") }
+    static var saveChangesButton: String { L10n.string("saveChangesButton") }
+    static var profileUpdatedSuccessToast: String { L10n.string("profileUpdatedSuccessToast") }
+    static var profilePictureLoadErrorToast: String { L10n.string("profilePictureLoadErrorToast") }
+    static var signInWithGoogle: String { L10n.string("signInWithGoogle") }
+
+    // Project screen
+    static var myProjectsHeading: String { L10n.string("myProjectsHeading") }
+    static var pleaseSignInProjectsLine1: String { L10n.string("pleaseSignInProjectsLine1") }
+    static var pleaseSignInProjectsLine2: String { L10n.string("pleaseSignInProjectsLine2") }
+    static var noProjectsFoundHeading: String { L10n.string("noProjectsFoundHeading") }
+    static var noProjectsFoundBody: String { L10n.string("noProjectsFoundBody") }
+    static var deleteFileTitle: String { L10n.string("deleteFileTitle") }
+    static var deleteFileMessage: String { L10n.string("deleteFileMessage") }
+    static var deleteAction: String { L10n.string("deleteAction") }
+
+    // QR Scanner / open-code bottom sheet
+    static var scanQrCodeHeading: String { L10n.string("scanQrCodeHeading") }
+    static var scanInstructions: String { L10n.string("scanInstructions") }
+    static var scanQrButton: String { L10n.string("scanQrButton") }
+    static var qrScannerNavTitle: String { L10n.string("qrScannerNavTitle") }
+    static var qrScanSuccessHeading: String { L10n.string("qrScanSuccessHeading") }
+    /// Format string with one %@ placeholder for the scanned project's file name.
+    static var qrFileDetectedMessageFormat: String { L10n.string("qrFileDetectedMessageFormat") }
+    static var startButton: String { L10n.string("startButton") }
+
+    // Playground (Run Robot / Blockly execution screen)
+    static var cancelledStatus: String { L10n.string("cancelledStatus") }
+    static var stopRobotButton: String { L10n.string("stopRobotButton") }
+    static var resetRobotButton: String { L10n.string("resetRobotButton") }
+    static var stopCarButton: String { L10n.string("stopCarButton") }
+    static var playgroundNavTitle: String { L10n.string("playgroundNavTitle") }
+
+    // Robot Info headings
+    static var robotTypeHeading: String { L10n.string("robotTypeHeading") }
+    static var sensorsHeading: String { L10n.string("sensorsHeading") }
+    /// Format string with one %@ placeholder for the sonar reading value, e.g. "Sonar %@ cm".
+    static var sonarReadingFormat: String { L10n.string("sonarReadingFormat") }
+    /// Format string with one %@ placeholder for the battery reading value, e.g. "Battery %@ V".
+    static var batteryReadingFormat: String { L10n.string("batteryReadingFormat") }
+
+    // Point Goal Navigation
+    static var goalReachedMessage: String { L10n.string("goalReachedMessage") }
+
+    // Model Management filter dropdown
+    static var modelFilterAll: String { L10n.string("modelFilterAll") }
+    static var modelFilterAllCaps: String { L10n.string("modelFilterAllCaps") }
+    static var modelFilterAutoPilot: String { L10n.string("modelFilterAutoPilot") }
+    static var modelFilterDetector: String { L10n.string("modelFilterDetector") }
+    static var modelFilterNavigation: String { L10n.string("modelFilterNavigation") }
+
+    // Data Collection / Autopilot server dropdown default state
+    static var noServer: String { L10n.string("noServer") }
+
     //open-code functions
     static let moveForward: String = "moveForward";
     static let loop: String = "loop";

--- a/ios/OpenBot/OpenBot/Utils/Strings.swift
+++ b/ios/OpenBot/OpenBot/Utils/Strings.swift
@@ -76,8 +76,8 @@ struct Strings {
     static var languageSubtitle: String { L10n.string("languageSubtitle") }
     static var systemDefault: String { L10n.string("systemDefault") }
     static var applyingLanguage: String { L10n.string("applyingLanguage") }
-    static let webSignalingServer: String = "Web Signaling Server"
-    static let webSignalingServerPlaceholder: String = "ws://192.168.1.40:8080/ws"
+    static var webSignalingServer: String { L10n.string("webSignalingServer") }
+    static var webSignalingServerPlaceholder: String { L10n.string("webSignalingServerPlaceholder") }
 
     // Notifications
     static let controllerConnected: String = "connectedWithControllerSuccessfully"

--- a/ios/OpenBot/OpenBot/Utils/Strings.swift
+++ b/ios/OpenBot/OpenBot/Utils/Strings.swift
@@ -4,47 +4,47 @@
 
 struct Strings {
     // Screens
-    static let OpenBot: String = "OpenBot"
-    static let freeRoam: String = "Free Roam"
-    static let dataCollection: String = "Data Collection"
-    static let controllerMapping: String = "Controller Mapping"
-    static let autoPilot: String = "Auto Pilot"
-    static let objectTracking: String = "Object Tracking"
-    static let modelManagement: String = "Model Management"
-    static let robotInfo: String = "Robot Info"
-    static let navigation: String = "Point Goal Navigation"
+    static var OpenBot: String { L10n.string("OpenBot") }
+    static var freeRoam: String { L10n.string("freeRoam") }
+    static var dataCollection: String { L10n.string("dataCollection") }
+    static var controllerMapping: String { L10n.string("controllerMapping") }
+    static var autoPilot: String { L10n.string("autoPilot") }
+    static var objectTracking: String { L10n.string("objectTracking") }
+    static var modelManagement: String { L10n.string("modelManagement") }
+    static var robotInfo: String { L10n.string("robotInfo") }
+    static var navigation: String { L10n.string("navigation") }
 
     // Misc
-    static let controller: String = "Controller"
-    static let speed: String = "Speed"
-    static let driveMode: String = "Drive Mode"
-    static let gamepad: String = "Gamepad"
-    static let phone: String = "Phone"
-    static let web: String = "Web"
-    static let joystick: String = "Joystick"
-    static let game: String = "Game"
-    static let dual: String = "Dual"
-    static let slow: String = "Slow"
-    static let medium: String = "Medium"
-    static let fast: String = "Fast"
-    static let logData: String = "Log Data"
-    static let previewResolutionMedium: String = "Preview Resolution (1280 x 720)"
-    static let previewResolutionLow: String = "Preview Resolution (960 x 540)"
-    static let previewResolutionHigh: String = "Preview Resolution (1920 x 1080)"
-    static let low: String = "Low"
-    static let high: String = "High"
-    static let modelResolution: String = "Model Resolution "
-    static let server: String = "Server"
+    static var controller: String { L10n.string("controller") }
+    static var speed: String { L10n.string("speed") }
+    static var driveMode: String { L10n.string("driveMode") }
+    static var gamepad: String { L10n.string("gamepad") }
+    static var phone: String { L10n.string("phone") }
+    static var web: String { L10n.string("web") }
+    static var joystick: String { L10n.string("joystick") }
+    static var game: String { L10n.string("game") }
+    static var dual: String { L10n.string("dual") }
+    static var slow: String { L10n.string("slow") }
+    static var medium: String { L10n.string("medium") }
+    static var fast: String { L10n.string("fast") }
+    static var logData: String { L10n.string("logData") }
+    static var previewResolutionMedium: String { L10n.string("previewResolutionMedium") }
+    static var previewResolutionLow: String { L10n.string("previewResolutionLow") }
+    static var previewResolutionHigh: String { L10n.string("previewResolutionHigh") }
+    static var low: String { L10n.string("low") }
+    static var high: String { L10n.string("high") }
+    static var modelResolution: String { L10n.string("modelResolution") }
+    static var server: String { L10n.string("server") }
     static let expendSetting: String = "expendSetting"
-    static let preview: String = "Preview"
-    static let training: String = "Training"
-    static let sensorData: String = "Sensor Data"
-    static let vehicle: String = "Vehicle"
-    static let gps: String = "GPS"
-    static let accelerometer: String = "Accelerometer"
-    static let magnetic: String = "Magnetic"
-    static let gyroscope: String = "Gyroscope"
-    static let delay: String = "Delay (ms)"
+    static var preview: String { L10n.string("preview") }
+    static var training: String { L10n.string("training") }
+    static var sensorData: String { L10n.string("sensorData") }
+    static var vehicle: String { L10n.string("vehicle") }
+    static var gps: String { L10n.string("gps") }
+    static var accelerometer: String { L10n.string("accelerometer") }
+    static var magnetic: String { L10n.string("magnetic") }
+    static var gyroscope: String { L10n.string("gyroscope") }
+    static var delay: String { L10n.string("delay") }
     static let images: String = "images"
     static let sensor: String = "sensor_data"
     static let timestamp: String = "timestamp[ns],frame\n"
@@ -53,24 +53,29 @@ struct Strings {
     static let comma: String = ","
     static let newLine: String = "\n"
     static let forwardSlash: String = "/"
-    static let Autopilot: String = "Autopilot"
-    static let ObjectTracking: String = "Object Tracking"
-    static let autoMode: String = "Auto Mode"
-    static let model: String = "Model"
-    static let input: String = "Input"
-    static let device: String = "Device"
-    static let threads: String = "Threads"
-    static let object: String = "Object"
-    static let confidence: String = "Confidence"
-    static let dynamicSpeed: String = "Dynamic Speed"
+    static var Autopilot: String { L10n.string("Autopilot") }
+    static var ObjectTracking: String { L10n.string("ObjectTracking") }
+    static var autoMode: String { L10n.string("autoMode") }
+    static var model: String { L10n.string("model") }
+    static var input: String { L10n.string("input") }
+    static var device: String { L10n.string("device") }
+    static var threads: String { L10n.string("threads") }
+    static var object: String { L10n.string("object") }
+    static var confidence: String { L10n.string("confidence") }
+    static var dynamicSpeed: String { L10n.string("dynamicSpeed") }
 
     // Settings
-    static let camera: String = "Camera"
-    static let microphone: String = "Microphone"
-    static let location: String = "Location"
-    static let permission: String = "Permissions"
+    static var camera: String { L10n.string("camera") }
+    static var microphone: String { L10n.string("microphone") }
+    static var location: String { L10n.string("location") }
+    static var permission: String { L10n.string("permission") }
     static let videoStreaming: String = "Video Streaming"
-    static let bluetooth: String = "Bluetooth"
+    static var bluetooth: String { L10n.string("bluetooth") }
+    static var general: String { L10n.string("general") }
+    static var language: String { L10n.string("language") }
+    static var languageSubtitle: String { L10n.string("languageSubtitle") }
+    static var systemDefault: String { L10n.string("systemDefault") }
+    static var applyingLanguage: String { L10n.string("applyingLanguage") }
 
     // Notifications
     static let controllerConnected: String = "connectedWithControllerSuccessfully"
@@ -119,55 +124,82 @@ struct Strings {
     static let motionHeader: String = "timestamp[ns]"
 
     // Bluetooth Status
-    static let connect: String = "Connect"
-    static let disconnect: String = "Disconnect"
-    static let connecting: String = "Connecting"
-    static let disconnecting: String = "Disconnecting"
+    static var connect: String { L10n.string("connect") }
+    static var disconnect: String { L10n.string("disconnect") }
+    static var connecting: String { L10n.string("connecting") }
+    static var disconnecting: String { L10n.string("disconnecting") }
 
     // Model management
-    static let modelDetails: String = "Model Details"
-    static let name: String = "Name"
-    static let type: String = "Type"
-    static let `class`: String = "Class"
-    static let inputOfModel: String = "Input(w x h)"
+    static var modelDetails: String { L10n.string("modelDetails") }
+    static var name: String { L10n.string("name") }
+    static var type: String { L10n.string("type") }
+    static var `class`: String { L10n.string("class") }
+    static var inputOfModel: String { L10n.string("inputOfModel") }
+    /// Functional file-extension constant (file lookups, name matching) -- must stay ".tflite" in
+    /// every language. See `tfliteLabel` for the translated on-screen copy.
     static let tflite: String = ".tflite"
-    static let cancel: String = "Cancel"
-    static let done: String = "Done"
-    static let file: String = "File"
-    static let url: String = "URL"
-    static let addNewModel: String = "Add New Model"
+    static var tfliteLabel: String { L10n.string("tfliteLabel") }
+    static var cancel: String { L10n.string("cancel") }
+    static var done: String { L10n.string("done") }
+    static var file: String { L10n.string("file") }
+    static var url: String { L10n.string("url") }
+    static var addNewModel: String { L10n.string("addNewModel") }
 
     // Robot Info
-    static let voltageDivider: String = "Voltage Divider"
-    static let sonarText: String = "Sonar"
-    static let bumperText: String = "Bumpers"
-    static let wheelOdometer: String = "Wheel Odometry"
-    static let front: String = "Front"
-    static let back: String = "Back"
-    static let led: String = "Leds"
-    static let indicatorText: String = "Indicators"
-    static let status: String = "Status"
-    static let motors: String = "Motors"
-    static let forward: String = "Forward"
-    static let backward: String = "Backward"
+    static var voltageDivider: String { L10n.string("voltageDivider") }
+    static var sonarText: String { L10n.string("sonarText") }
+    static var bumperText: String { L10n.string("bumperText") }
+    static var wheelOdometer: String { L10n.string("wheelOdometer") }
+    static var front: String { L10n.string("front") }
+    static var back: String { L10n.string("back") }
+    static var led: String { L10n.string("led") }
+    static var indicatorText: String { L10n.string("indicatorText") }
+    static var status: String { L10n.string("status") }
+    static var motors: String { L10n.string("motors") }
+    static var forward: String { L10n.string("forward") }
+    static var backward: String { L10n.string("backward") }
+    /// Functional Blockly JS bridge function name -- must stay "Stop" in every language.
+    /// See `stopLabel` for the translated on-screen copy.
     static let stop: String = "Stop"
-    static let readings: String = "Readings"
-    static let battery: String = "Battery **.* V"
-    static let speedText: String = "Speed (l,r) ***,*** rpm"
-    static let sonarLabel: String = "Sonar *** cm"
-    static let sendCommand: String = "Send Commands"
-    static let lightLabel: String = "Lights"
+    static var stopLabel: String { L10n.string("stopLabel") }
+    static var readings: String { L10n.string("readings") }
+    static var battery: String { L10n.string("battery") }
+    static var speedText: String { L10n.string("speedText") }
+    static var sonarLabel: String { L10n.string("sonarLabel") }
+    static var sendCommand: String { L10n.string("sendCommand") }
+    static var lightLabel: String { L10n.string("lightLabel") }
 
-    //Navigation
-    static let setGoal: String = "Set Goal"
-    static let setGoalText: String = "Mount the phone on the robot and \n specify a goal. The robot will try to\n reach the goal after pressing start."
-    static let left: String = "Left"
-    static let meter: String = "[m]"
+    // Navigation
+    static var setGoal: String { L10n.string("setGoal") }
+    static var setGoalText: String { L10n.string("setGoalText") }
+    static var left: String { L10n.string("left") }
+    static var meter: String { L10n.string("meter") }
+    /// Functional Blockly JS bridge function name -- must stay "START" in every language.
+    /// See `startLabel` for the translated on-screen copy.
     static let start: String = "START"
-    static let canceled: String = "CANCEL"
-    static let info: String = "Info"
-    static let restart: String = "Restart"
+    static var startLabel: String { L10n.string("startLabel") }
+    static var canceled: String { L10n.string("canceled") }
+    static var info: String { L10n.string("info") }
+    static var restart: String { L10n.string("restart") }
 
+    // Settings > Permissions
+    static var important: String { L10n.string("important") }
+    static var cameraAccessRequiredMessage: String { L10n.string("cameraAccessRequiredMessage") }
+    /// Format string with one %@ placeholder for the (already-localized) permission name, e.g. "Please allow %@ access for OpenBot".
+    static var allowPermissionMessageFormat: String { L10n.string("allowPermissionMessageFormat") }
+    /// Format string with one %@ placeholder for the (already-localized) permission name, e.g. "Allow %@".
+    static var allowButtonFormat: String { L10n.string("allowButtonFormat") }
+
+    // Logout / open-code UI
+    static var logOut: String { L10n.string("logOut") }
+    static var confirmLogoutTitle: String { L10n.string("confirmLogoutTitle") }
+    static var confirmLogoutMessage: String { L10n.string("confirmLogoutMessage") }
+    static var codeExecuting: String { L10n.string("codeExecuting") }
+
+    // Tab bar
+    static var projectsTab: String { L10n.string("projectsTab") }
+    static var homeTab: String { L10n.string("homeTab") }
+    static var profileTab: String { L10n.string("profileTab") }
 
     //open-code functions
     static let moveForward: String = "moveForward";

--- a/ios/OpenBot/OpenBot/Utils/extensions/UIViewExtension.swift
+++ b/ios/OpenBot/OpenBot/Utils/extensions/UIViewExtension.swift
@@ -227,7 +227,7 @@ class openCodeRunBottomSheet: UIView {
         DispatchQueue.main.async {
             self.createErrorHeading()
             self.createErrorMsg()
-            fileName == "" ?  self.createCancel(btnName: "Scan Qr") : self.createCancel(btnName: "Cancel")
+            fileName == "" ?  self.createCancel(btnName: Strings.scanQrButton) : self.createCancel(btnName: Strings.cancel)
 
         }
 
@@ -251,14 +251,14 @@ class openCodeRunBottomSheet: UIView {
     }
 
     private func createBottomSheetHeading() {
-        let heading = CustomLabel(text: "QR scanned successfully",
+        let heading = CustomLabel(text: Strings.qrScanSuccessHeading,
                 fontSize: 18, fontColor: Colors.textColor ?? .black, frame: CGRect(x: 19, y: 33, width: 290, height: 40));
         heading.font = HelveticaNeue.bold(size: 15);
         bottomSheet.addSubview(heading);
     }
 
     private func createBottomSheetMsg(fileName: String,isScannerFragment : Bool) {
-        let message = "\(fileName) file detected. Start to execute the code on your OpenBot."
+        let message = String(format: Strings.qrFileDetectedMessageFormat, fileName)
         let font = UIFont(name: "HelveticaNeue", size: 16)!
         _ = (message as NSString).boundingRect(with: CGSize(width: 320, height: CGFloat.greatestFiniteMagnitude), options: .usesLineFragmentOrigin, attributes: [.font: font], context: nil)
         let msg =   isScannerFragment == true ? CustomLabel(text: message, fontSize: 15,
@@ -278,7 +278,7 @@ class openCodeRunBottomSheet: UIView {
     */
     private func createStartBtn() {
         startBtn.backgroundColor = Colors.title;
-        startBtn.setTitle("Start", for: .normal);
+        startBtn.setTitle(Strings.startButton, for: .normal);
         startBtn.addTarget(nil, action: #selector(start), for: .touchUpInside);
         startBtn.layer.cornerRadius = 10;
         bottomSheet.addSubview(startBtn);
@@ -288,7 +288,7 @@ class openCodeRunBottomSheet: UIView {
      Method to create Cancel button and reload the Scanner
      */
     private func createCancelBtn() {
-        cancelBtn.setTitle("Cancel", for: .normal);
+        cancelBtn.setTitle(Strings.cancel, for: .normal);
         cancelBtn.layer.borderWidth = 1;
         cancelBtn.layer.borderColor = Colors.title?.cgColor;
         cancelBtn.clipsToBounds = true;
@@ -340,7 +340,7 @@ class openCodeRunBottomSheet: UIView {
      Function to create Error Heading  mukerian
      */
     private func createErrorHeading() {
-        let errorHeading = CustomLabel(text: "Error",
+        let errorHeading = CustomLabel(text: Strings.errorHeading,
                 fontSize: 18, fontColor: Colors.textColor ?? .black, frame: CGRect(x: 19, y: 23, width: 60, height: 40));
         errorHeading.font = HelveticaNeue.bold(size: 15);
         bottomSheet.addSubview(errorHeading);
@@ -350,7 +350,7 @@ class openCodeRunBottomSheet: UIView {
      Function to create Error Message
      */
     private func createErrorMsg() {
-        let msg = CustomLabel(text: "Oops! Something went wrong.Please try again.", fontSize: 15, fontColor: Colors.textColor ?? .black, frame: CGRect(x: 19, y: 57, width: 330, height: 40));
+        let msg = CustomLabel(text: Strings.genericErrorMessage, fontSize: 15, fontColor: Colors.textColor ?? .black, frame: CGRect(x: 19, y: 57, width: 330, height: 40));
         bottomSheet.addSubview(msg);
     }
 

--- a/ios/OpenBot/OpenBot/de.lproj/Localizable.strings
+++ b/ios/OpenBot/OpenBot/de.lproj/Localizable.strings
@@ -61,6 +61,8 @@
 "languageSubtitle" = "Anzeigesprache der App wählen";
 "systemDefault" = "Systemstandard";
 "applyingLanguage" = "Sprache wird übernommen…";
+"webSignalingServer" = "Web-Signalisierungsserver";
+"webSignalingServerPlaceholder" = "ws://192.168.1.40:8080/ws";
 
 /* Bluetooth Status */
 "connect" = "Verbinden";

--- a/ios/OpenBot/OpenBot/de.lproj/Localizable.strings
+++ b/ios/OpenBot/OpenBot/de.lproj/Localizable.strings
@@ -1,0 +1,130 @@
+/* Screens */
+"OpenBot" = "OpenBot";
+"freeRoam" = "Freier Modus";
+"dataCollection" = "Datensammlung";
+"controllerMapping" = "Controller-Zuordnung";
+"autoPilot" = "Autopilot";
+"objectTracking" = "Objektverfolgung";
+"modelManagement" = "Modellverwaltung";
+"robotInfo" = "Roboterinfo";
+"navigation" = "Zielnavigation";
+
+/* Misc */
+"controller" = "Controller";
+"speed" = "Geschwindigkeit";
+"driveMode" = "Fahrmodus";
+"gamepad" = "Gamepad";
+"phone" = "Telefon";
+"web" = "Web";
+"joystick" = "Joystick";
+"game" = "Spiel";
+"dual" = "Dual";
+"slow" = "Langsam";
+"medium" = "Mittel";
+"fast" = "Schnell";
+"logData" = "Daten protokollieren";
+"previewResolutionMedium" = "Vorschauauflösung (1280 x 720)";
+"previewResolutionLow" = "Vorschauauflösung (960 x 540)";
+"previewResolutionHigh" = "Vorschauauflösung (1920 x 1080)";
+"low" = "Niedrig";
+"high" = "Hoch";
+"modelResolution" = "Modellauflösung ";
+"server" = "Server";
+"preview" = "Vorschau";
+"training" = "Training";
+"sensorData" = "Sensordaten";
+"vehicle" = "Fahrzeug";
+"gps" = "GPS";
+"accelerometer" = "Beschleunigungssensor";
+"magnetic" = "Magnetfeld";
+"gyroscope" = "Gyroskop";
+"delay" = "Verzögerung (ms)";
+"Autopilot" = "Autopilot";
+"ObjectTracking" = "Objektverfolgung";
+"autoMode" = "Automodus";
+"model" = "Modell";
+"input" = "Eingabe";
+"device" = "Gerät";
+"threads" = "Threads";
+"object" = "Objekt";
+"confidence" = "Konfidenz";
+"dynamicSpeed" = "Dynamische Geschwindigkeit";
+
+/* Settings */
+"camera" = "Kamera";
+"microphone" = "Mikrofon";
+"location" = "Standort";
+"permission" = "Berechtigungen";
+"bluetooth" = "Bluetooth";
+"general" = "Allgemein";
+"language" = "Sprache";
+"languageSubtitle" = "Anzeigesprache der App wählen";
+"systemDefault" = "Systemstandard";
+"applyingLanguage" = "Sprache wird übernommen…";
+
+/* Bluetooth Status */
+"connect" = "Verbinden";
+"disconnect" = "Trennen";
+"connecting" = "Verbindet";
+"disconnecting" = "Trennt Verbindung";
+
+/* Model management */
+"modelDetails" = "Modelldetails";
+"name" = "Name";
+"type" = "Typ";
+"class" = "Klasse";
+"inputOfModel" = "Eingabe (B x H)";
+"tfliteLabel" = ".tflite";
+"cancel" = "Abbrechen";
+"done" = "Fertig";
+"file" = "Datei";
+"url" = "URL";
+"addNewModel" = "Neues Modell hinzufügen";
+
+/* Robot Info */
+"voltageDivider" = "Spannungsteiler";
+"sonarText" = "Sonar";
+"bumperText" = "Stoßfänger";
+"wheelOdometer" = "Radodometrie";
+"front" = "Vorne";
+"back" = "Hinten";
+"led" = "LEDs";
+"indicatorText" = "Blinker";
+"status" = "Status";
+"motors" = "Motoren";
+"forward" = "Vorwärts";
+"backward" = "Rückwärts";
+"stopLabel" = "Stopp";
+"readings" = "Messwerte";
+"battery" = "Akku **.* V";
+"speedText" = "Geschw. (l,r) ***,*** U/min";
+"sonarLabel" = "Sonar *** cm";
+"sendCommand" = "Befehle senden";
+"lightLabel" = "Lichter";
+
+/* Navigation */
+"setGoal" = "Ziel festlegen";
+"setGoalText" = "Befestige das Telefon am Roboter und \n lege ein Ziel fest. Der Roboter versucht,\n das Ziel nach dem Start zu erreichen.";
+"left" = "Links";
+"meter" = "[m]";
+"startLabel" = "START";
+"canceled" = "ABBRECHEN";
+"info" = "Info";
+"restart" = "Neu starten";
+
+/* Settings > Permissions */
+"important" = "WICHTIG";
+"cameraAccessRequiredMessage" = "OpenBot benötigt Zugriff auf die Kamera";
+"allowPermissionMessageFormat" = "Bitte erlaube OpenBot den Zugriff auf %@";
+"allowButtonFormat" = "%@ erlauben";
+
+/* Logout / open-code UI */
+"logOut" = "ABMELDEN";
+"confirmLogoutTitle" = "Abmeldung bestätigen";
+"confirmLogoutMessage" = "Möchtest du dich wirklich abmelden?";
+"codeExecuting" = "Dein Code wird ausgeführt..";
+
+/* Tab bar */
+"projectsTab" = "Projekte";
+"homeTab" = "Start";
+"profileTab" = "Profil";

--- a/ios/OpenBot/OpenBot/de.lproj/Localizable.strings
+++ b/ios/OpenBot/OpenBot/de.lproj/Localizable.strings
@@ -128,3 +128,73 @@
 "projectsTab" = "Projekte";
 "homeTab" = "Start";
 "profileTab" = "Profil";
+
+/* Loading / generic alerts */
+"loadingTitle" = "Lädt";
+"loadingProfileMessage" = "Bitte warten, während das Profil geladen wird …";
+"loadingDataMessage" = "Bitte warten, während die Daten geladen werden …";
+"pleaseWaitMessage" = "Bitte warten …";
+"errorHeading" = "Fehler";
+"genericErrorMessage" = "Hoppla! Etwas ist schiefgelaufen. Bitte versuche es erneut.";
+"okAction" = "OK";
+
+/* Profile screen */
+"myProfileHeading" = "Mein Profil";
+"setupProfilePromptLine1" = "Richte dein Profil ein, indem du dich mit";
+"setupProfilePromptLine2" = "deinem Google-Konto anmeldest.";
+"editProfile" = "Profil bearbeiten";
+"logoutMenuItem" = "Abmelden";
+"firstNameFieldLabel" = "Vorname";
+"lastNameFieldLabel" = "Nachname";
+"dateOfBirthFieldLabel" = "Geburtsdatum";
+"emailFieldLabel" = "E-Mail";
+"unknownFallback" = "Unbekannt";
+"saveChangesButton" = "Änderungen speichern";
+"profileUpdatedSuccessToast" = "Profil erfolgreich aktualisiert";
+"profilePictureLoadErrorToast" = "Fehler beim Laden des Profilbilds";
+"signInWithGoogle" = "Mit Google anmelden";
+
+/* Project screen */
+"myProjectsHeading" = "Meine Projekte";
+"pleaseSignInProjectsLine1" = "Bitte melde dich an, um auf deine";
+"pleaseSignInProjectsLine2" = "Projekte zuzugreifen.";
+"noProjectsFoundHeading" = "Hoppla! Keine Projekte gefunden.";
+"noProjectsFoundBody" = "Es sieht so aus, als gäbe es noch keine\nProjekte in deinem Google Drive.";
+"deleteFileTitle" = "Diese Datei löschen";
+"deleteFileMessage" = "Diese Datei kann später nicht wiederhergestellt werden";
+"deleteAction" = "Löschen";
+
+/* QR Scanner / open-code bottom sheet */
+"scanQrCodeHeading" = "QR-Code scannen";
+"scanInstructions" = "Platziere den QR-Code im Rahmen, um ihn zu scannen. Bitte nicht wackeln, damit das Ergebnis schneller erscheint.";
+"scanQrButton" = "QR scannen";
+"qrScannerNavTitle" = "QR-Scanner";
+"qrScanSuccessHeading" = "QR-Code erfolgreich gescannt";
+"qrFileDetectedMessageFormat" = "Datei „%@“ erkannt. Starte die Ausführung des Codes auf deinem OpenBot.";
+"startButton" = "Start";
+
+/* Playground (Run Robot / Blockly execution screen) */
+"cancelledStatus" = "Abgebrochen";
+"stopRobotButton" = "Roboter stoppen";
+"resetRobotButton" = "Roboter zurücksetzen";
+"stopCarButton" = "Fahrzeug stoppen";
+"playgroundNavTitle" = "Spielwiese";
+
+/* Robot Info headings */
+"robotTypeHeading" = "Robotertyp";
+"sensorsHeading" = "Sensoren";
+"sonarReadingFormat" = "Sonar %@ cm";
+"batteryReadingFormat" = "Akku %@ V";
+
+/* Point Goal Navigation */
+"goalReachedMessage" = "Ziel erreicht";
+
+/* Model Management filter dropdown */
+"modelFilterAll" = "Alle";
+"modelFilterAllCaps" = "ALLE";
+"modelFilterAutoPilot" = "Autopilot";
+"modelFilterDetector" = "Detektor";
+"modelFilterNavigation" = "Navigation";
+
+/* Data Collection / Autopilot server dropdown default state */
+"noServer" = "Kein Server";

--- a/ios/OpenBot/OpenBot/en.lproj/Localizable.strings
+++ b/ios/OpenBot/OpenBot/en.lproj/Localizable.strings
@@ -61,6 +61,8 @@
 "languageSubtitle" = "Choose the app display language";
 "systemDefault" = "System Default";
 "applyingLanguage" = "Applying language…";
+"webSignalingServer" = "Web Signaling Server";
+"webSignalingServerPlaceholder" = "ws://192.168.1.40:8080/ws";
 
 /* Bluetooth Status */
 "connect" = "Connect";

--- a/ios/OpenBot/OpenBot/en.lproj/Localizable.strings
+++ b/ios/OpenBot/OpenBot/en.lproj/Localizable.strings
@@ -128,3 +128,73 @@
 "projectsTab" = "Projects";
 "homeTab" = "Home";
 "profileTab" = "Profile";
+
+/* Loading / generic alerts */
+"loadingTitle" = "Loading";
+"loadingProfileMessage" = "Please wait while we load the profile...";
+"loadingDataMessage" = "Please wait while we load data...";
+"pleaseWaitMessage" = "Please wait...";
+"errorHeading" = "Error";
+"genericErrorMessage" = "Oops! Something went wrong. Please try again.";
+"okAction" = "OK";
+
+/* Profile screen */
+"myProfileHeading" = "My Profile";
+"setupProfilePromptLine1" = "Set up your profile by signing in with";
+"setupProfilePromptLine2" = "your Google account.";
+"editProfile" = "Edit Profile";
+"logoutMenuItem" = "Logout";
+"firstNameFieldLabel" = "First Name";
+"lastNameFieldLabel" = "Last Name";
+"dateOfBirthFieldLabel" = "Date Of Birth";
+"emailFieldLabel" = "Email";
+"unknownFallback" = "Unknown";
+"saveChangesButton" = "Save Changes";
+"profileUpdatedSuccessToast" = "Profile Updated Successfully";
+"profilePictureLoadErrorToast" = "Error while loading profile picture";
+"signInWithGoogle" = "Sign-in with Google";
+
+/* Project screen */
+"myProjectsHeading" = "My Projects";
+"pleaseSignInProjectsLine1" = "Please sign in first to access your";
+"pleaseSignInProjectsLine2" = "projects.";
+"noProjectsFoundHeading" = "Oops! No projects found.";
+"noProjectsFoundBody" = "Looks like there are no projects\nin your google drive yet.";
+"deleteFileTitle" = "Delete this file";
+"deleteFileMessage" = "You cannot restore this file later";
+"deleteAction" = "Delete";
+
+/* QR Scanner / open-code bottom sheet */
+"scanQrCodeHeading" = "Scan Qr Code";
+"scanInstructions" = "Place qr code inside the frame to scan. Please avoid shake to get results quickly.";
+"scanQrButton" = "Scan QR";
+"qrScannerNavTitle" = "Qr Scanner";
+"qrScanSuccessHeading" = "QR scanned successfully";
+"qrFileDetectedMessageFormat" = "%@ file detected. Start to execute the code on your OpenBot.";
+"startButton" = "Start";
+
+/* Playground (Run Robot / Blockly execution screen) */
+"cancelledStatus" = "Cancelled";
+"stopRobotButton" = "Stop Robot";
+"resetRobotButton" = "Reset Robot";
+"stopCarButton" = "Stop Car";
+"playgroundNavTitle" = "Playground";
+
+/* Robot Info headings */
+"robotTypeHeading" = "Robot Type";
+"sensorsHeading" = "Sensors";
+"sonarReadingFormat" = "Sonar %@ cm";
+"batteryReadingFormat" = "Battery %@ V";
+
+/* Point Goal Navigation */
+"goalReachedMessage" = "Goal reached";
+
+/* Model Management filter dropdown */
+"modelFilterAll" = "All";
+"modelFilterAllCaps" = "ALL";
+"modelFilterAutoPilot" = "AutoPilot";
+"modelFilterDetector" = "Detector";
+"modelFilterNavigation" = "Navigation";
+
+/* Data Collection / Autopilot server dropdown default state */
+"noServer" = "No Server";

--- a/ios/OpenBot/OpenBot/en.lproj/Localizable.strings
+++ b/ios/OpenBot/OpenBot/en.lproj/Localizable.strings
@@ -1,0 +1,130 @@
+/* Screens */
+"OpenBot" = "OpenBot";
+"freeRoam" = "Free Roam";
+"dataCollection" = "Data Collection";
+"controllerMapping" = "Controller Mapping";
+"autoPilot" = "Auto Pilot";
+"objectTracking" = "Object Tracking";
+"modelManagement" = "Model Management";
+"robotInfo" = "Robot Info";
+"navigation" = "Point Goal Navigation";
+
+/* Misc */
+"controller" = "Controller";
+"speed" = "Speed";
+"driveMode" = "Drive Mode";
+"gamepad" = "Gamepad";
+"phone" = "Phone";
+"web" = "Web";
+"joystick" = "Joystick";
+"game" = "Game";
+"dual" = "Dual";
+"slow" = "Slow";
+"medium" = "Medium";
+"fast" = "Fast";
+"logData" = "Log Data";
+"previewResolutionMedium" = "Preview Resolution (1280 x 720)";
+"previewResolutionLow" = "Preview Resolution (960 x 540)";
+"previewResolutionHigh" = "Preview Resolution (1920 x 1080)";
+"low" = "Low";
+"high" = "High";
+"modelResolution" = "Model Resolution ";
+"server" = "Server";
+"preview" = "Preview";
+"training" = "Training";
+"sensorData" = "Sensor Data";
+"vehicle" = "Vehicle";
+"gps" = "GPS";
+"accelerometer" = "Accelerometer";
+"magnetic" = "Magnetic";
+"gyroscope" = "Gyroscope";
+"delay" = "Delay (ms)";
+"Autopilot" = "Autopilot";
+"ObjectTracking" = "Object Tracking";
+"autoMode" = "Auto Mode";
+"model" = "Model";
+"input" = "Input";
+"device" = "Device";
+"threads" = "Threads";
+"object" = "Object";
+"confidence" = "Confidence";
+"dynamicSpeed" = "Dynamic Speed";
+
+/* Settings */
+"camera" = "Camera";
+"microphone" = "Microphone";
+"location" = "Location";
+"permission" = "Permissions";
+"bluetooth" = "Bluetooth";
+"general" = "General";
+"language" = "Language";
+"languageSubtitle" = "Choose the app display language";
+"systemDefault" = "System Default";
+"applyingLanguage" = "Applying language…";
+
+/* Bluetooth Status */
+"connect" = "Connect";
+"disconnect" = "Disconnect";
+"connecting" = "Connecting";
+"disconnecting" = "Disconnecting";
+
+/* Model management */
+"modelDetails" = "Model Details";
+"name" = "Name";
+"type" = "Type";
+"class" = "Class";
+"inputOfModel" = "Input(w x h)";
+"tfliteLabel" = ".tflite";
+"cancel" = "Cancel";
+"done" = "Done";
+"file" = "File";
+"url" = "URL";
+"addNewModel" = "Add New Model";
+
+/* Robot Info */
+"voltageDivider" = "Voltage Divider";
+"sonarText" = "Sonar";
+"bumperText" = "Bumpers";
+"wheelOdometer" = "Wheel Odometry";
+"front" = "Front";
+"back" = "Back";
+"led" = "Leds";
+"indicatorText" = "Indicators";
+"status" = "Status";
+"motors" = "Motors";
+"forward" = "Forward";
+"backward" = "Backward";
+"stopLabel" = "Stop";
+"readings" = "Readings";
+"battery" = "Battery **.* V";
+"speedText" = "Speed (l,r) ***,*** rpm";
+"sonarLabel" = "Sonar *** cm";
+"sendCommand" = "Send Commands";
+"lightLabel" = "Lights";
+
+/* Navigation */
+"setGoal" = "Set Goal";
+"setGoalText" = "Mount the phone on the robot and \n specify a goal. The robot will try to\n reach the goal after pressing start.";
+"left" = "Left";
+"meter" = "[m]";
+"startLabel" = "START";
+"canceled" = "CANCEL";
+"info" = "Info";
+"restart" = "Restart";
+
+/* Settings > Permissions */
+"important" = "IMPORTANT";
+"cameraAccessRequiredMessage" = "Camera access required for OpenBot";
+"allowPermissionMessageFormat" = "Please allow %@ access for OpenBot";
+"allowButtonFormat" = "Allow %@";
+
+/* Logout / open-code UI */
+"logOut" = "LOG OUT";
+"confirmLogoutTitle" = "Confirm Logout";
+"confirmLogoutMessage" = "Are you sure you want to logout?";
+"codeExecuting" = "Your code is executing..";
+
+/* Tab bar */
+"projectsTab" = "Projects";
+"homeTab" = "Home";
+"profileTab" = "Profile";

--- a/ios/OpenBot/OpenBot/es.lproj/Localizable.strings
+++ b/ios/OpenBot/OpenBot/es.lproj/Localizable.strings
@@ -61,6 +61,8 @@
 "languageSubtitle" = "Elige el idioma de visualización de la app";
 "systemDefault" = "Predeterminado del sistema";
 "applyingLanguage" = "Aplicando idioma…";
+"webSignalingServer" = "Servidor de señalización web";
+"webSignalingServerPlaceholder" = "ws://192.168.1.40:8080/ws";
 
 /* Bluetooth Status */
 "connect" = "Conectar";

--- a/ios/OpenBot/OpenBot/es.lproj/Localizable.strings
+++ b/ios/OpenBot/OpenBot/es.lproj/Localizable.strings
@@ -128,3 +128,73 @@
 "projectsTab" = "Proyectos";
 "homeTab" = "Inicio";
 "profileTab" = "Perfil";
+
+/* Loading / generic alerts */
+"loadingTitle" = "Cargando";
+"loadingProfileMessage" = "Espera mientras cargamos el perfil...";
+"loadingDataMessage" = "Espera mientras cargamos los datos...";
+"pleaseWaitMessage" = "Espera un momento...";
+"errorHeading" = "Error";
+"genericErrorMessage" = "¡Vaya! Algo salió mal. Inténtalo de nuevo.";
+"okAction" = "Aceptar";
+
+/* Profile screen */
+"myProfileHeading" = "Mi Perfil";
+"setupProfilePromptLine1" = "Configura tu perfil iniciando sesión con";
+"setupProfilePromptLine2" = "tu cuenta de Google.";
+"editProfile" = "Editar Perfil";
+"logoutMenuItem" = "Cerrar sesión";
+"firstNameFieldLabel" = "Nombre";
+"lastNameFieldLabel" = "Apellido";
+"dateOfBirthFieldLabel" = "Fecha de Nacimiento";
+"emailFieldLabel" = "Correo electrónico";
+"unknownFallback" = "Desconocido";
+"saveChangesButton" = "Guardar Cambios";
+"profileUpdatedSuccessToast" = "Perfil actualizado correctamente";
+"profilePictureLoadErrorToast" = "Error al cargar la foto de perfil";
+"signInWithGoogle" = "Iniciar sesión con Google";
+
+/* Project screen */
+"myProjectsHeading" = "Mis Proyectos";
+"pleaseSignInProjectsLine1" = "Inicia sesión primero para acceder a tus";
+"pleaseSignInProjectsLine2" = "proyectos.";
+"noProjectsFoundHeading" = "¡Vaya! No se encontraron proyectos.";
+"noProjectsFoundBody" = "Parece que todavía no hay proyectos\nen tu Google Drive.";
+"deleteFileTitle" = "Eliminar este archivo";
+"deleteFileMessage" = "No podrás restaurar este archivo más tarde";
+"deleteAction" = "Eliminar";
+
+/* QR Scanner / open-code bottom sheet */
+"scanQrCodeHeading" = "Escanear Código QR";
+"scanInstructions" = "Coloca el código QR dentro del marco para escanearlo. Evita mover el teléfono para obtener resultados más rápido.";
+"scanQrButton" = "Escanear QR";
+"qrScannerNavTitle" = "Escáner QR";
+"qrScanSuccessHeading" = "Código QR escaneado correctamente";
+"qrFileDetectedMessageFormat" = "Archivo %@ detectado. Comenzando a ejecutar el código en tu OpenBot.";
+"startButton" = "Iniciar";
+
+/* Playground (Run Robot / Blockly execution screen) */
+"cancelledStatus" = "Cancelado";
+"stopRobotButton" = "Detener Robot";
+"resetRobotButton" = "Reiniciar Robot";
+"stopCarButton" = "Detener Vehículo";
+"playgroundNavTitle" = "Zona de Pruebas";
+
+/* Robot Info headings */
+"robotTypeHeading" = "Tipo de Robot";
+"sensorsHeading" = "Sensores";
+"sonarReadingFormat" = "Sonar %@ cm";
+"batteryReadingFormat" = "Batería %@ V";
+
+/* Point Goal Navigation */
+"goalReachedMessage" = "Meta alcanzada";
+
+/* Model Management filter dropdown */
+"modelFilterAll" = "Todos";
+"modelFilterAllCaps" = "TODOS";
+"modelFilterAutoPilot" = "Piloto Automático";
+"modelFilterDetector" = "Detector";
+"modelFilterNavigation" = "Navegación";
+
+/* Data Collection / Autopilot server dropdown default state */
+"noServer" = "Sin Servidor";

--- a/ios/OpenBot/OpenBot/es.lproj/Localizable.strings
+++ b/ios/OpenBot/OpenBot/es.lproj/Localizable.strings
@@ -1,0 +1,130 @@
+/* Screens */
+"OpenBot" = "OpenBot";
+"freeRoam" = "Modo Libre";
+"dataCollection" = "Recopilación de Datos";
+"controllerMapping" = "Asignación del Mando";
+"autoPilot" = "Piloto Automático";
+"objectTracking" = "Seguimiento de Objetos";
+"modelManagement" = "Gestión de Modelos";
+"robotInfo" = "Información del Robot";
+"navigation" = "Navegación a un Punto";
+
+/* Misc */
+"controller" = "Mando";
+"speed" = "Velocidad";
+"driveMode" = "Modo de Conducción";
+"gamepad" = "Mando de Juego";
+"phone" = "Teléfono";
+"web" = "Web";
+"joystick" = "Joystick";
+"game" = "Juego";
+"dual" = "Dual";
+"slow" = "Lento";
+"medium" = "Medio";
+"fast" = "Rápido";
+"logData" = "Registrar Datos";
+"previewResolutionMedium" = "Resolución de Vista Previa (1280 x 720)";
+"previewResolutionLow" = "Resolución de Vista Previa (960 x 540)";
+"previewResolutionHigh" = "Resolución de Vista Previa (1920 x 1080)";
+"low" = "Baja";
+"high" = "Alta";
+"modelResolution" = "Resolución del Modelo ";
+"server" = "Servidor";
+"preview" = "Vista Previa";
+"training" = "Entrenamiento";
+"sensorData" = "Datos de Sensores";
+"vehicle" = "Vehículo";
+"gps" = "GPS";
+"accelerometer" = "Acelerómetro";
+"magnetic" = "Magnético";
+"gyroscope" = "Giroscopio";
+"delay" = "Retraso (ms)";
+"Autopilot" = "Piloto Automático";
+"ObjectTracking" = "Seguimiento de Objetos";
+"autoMode" = "Modo Automático";
+"model" = "Modelo";
+"input" = "Entrada";
+"device" = "Dispositivo";
+"threads" = "Hilos";
+"object" = "Objeto";
+"confidence" = "Confianza";
+"dynamicSpeed" = "Velocidad Dinámica";
+
+/* Settings */
+"camera" = "Cámara";
+"microphone" = "Micrófono";
+"location" = "Ubicación";
+"permission" = "Permisos";
+"bluetooth" = "Bluetooth";
+"general" = "General";
+"language" = "Idioma";
+"languageSubtitle" = "Elige el idioma de visualización de la app";
+"systemDefault" = "Predeterminado del sistema";
+"applyingLanguage" = "Aplicando idioma…";
+
+/* Bluetooth Status */
+"connect" = "Conectar";
+"disconnect" = "Desconectar";
+"connecting" = "Conectando";
+"disconnecting" = "Desconectando";
+
+/* Model management */
+"modelDetails" = "Detalles del Modelo";
+"name" = "Nombre";
+"type" = "Tipo";
+"class" = "Clase";
+"inputOfModel" = "Entrada (an x al)";
+"tfliteLabel" = ".tflite";
+"cancel" = "Cancelar";
+"done" = "Hecho";
+"file" = "Archivo";
+"url" = "URL";
+"addNewModel" = "Añadir Nuevo Modelo";
+
+/* Robot Info */
+"voltageDivider" = "Divisor de Voltaje";
+"sonarText" = "Sonar";
+"bumperText" = "Parachoques";
+"wheelOdometer" = "Odometría de Ruedas";
+"front" = "Frente";
+"back" = "Atrás";
+"led" = "Luces LED";
+"indicatorText" = "Intermitentes";
+"status" = "Estado";
+"motors" = "Motores";
+"forward" = "Adelante";
+"backward" = "Atrás";
+"stopLabel" = "Detener";
+"readings" = "Lecturas";
+"battery" = "Batería **.* V";
+"speedText" = "Velocidad (i,d) ***,*** rpm";
+"sonarLabel" = "Sonar *** cm";
+"sendCommand" = "Enviar Comandos";
+"lightLabel" = "Luces";
+
+/* Navigation */
+"setGoal" = "Establecer Meta";
+"setGoalText" = "Monta el teléfono en el robot y \n especifica una meta. El robot intentará\n alcanzarla después de pulsar iniciar.";
+"left" = "Izquierda";
+"meter" = "[m]";
+"startLabel" = "INICIAR";
+"canceled" = "CANCELAR";
+"info" = "Información";
+"restart" = "Reiniciar";
+
+/* Settings > Permissions */
+"important" = "IMPORTANTE";
+"cameraAccessRequiredMessage" = "OpenBot necesita acceso a la cámara";
+"allowPermissionMessageFormat" = "Permite que OpenBot acceda a %@";
+"allowButtonFormat" = "Permitir %@";
+
+/* Logout / open-code UI */
+"logOut" = "CERRAR SESIÓN";
+"confirmLogoutTitle" = "Confirmar Cierre de Sesión";
+"confirmLogoutMessage" = "¿Seguro que quieres cerrar sesión?";
+"codeExecuting" = "Tu código se está ejecutando..";
+
+/* Tab bar */
+"projectsTab" = "Proyectos";
+"homeTab" = "Inicio";
+"profileTab" = "Perfil";

--- a/ios/OpenBot/OpenBot/fr.lproj/Localizable.strings
+++ b/ios/OpenBot/OpenBot/fr.lproj/Localizable.strings
@@ -1,0 +1,130 @@
+/* Screens */
+"OpenBot" = "OpenBot";
+"freeRoam" = "Mode Libre";
+"dataCollection" = "Collecte de Données";
+"controllerMapping" = "Configuration du Contrôleur";
+"autoPilot" = "Pilote Automatique";
+"objectTracking" = "Suivi d'Objets";
+"modelManagement" = "Gestion des Modèles";
+"robotInfo" = "Infos du Robot";
+"navigation" = "Navigation vers un Point";
+
+/* Misc */
+"controller" = "Contrôleur";
+"speed" = "Vitesse";
+"driveMode" = "Mode de Conduite";
+"gamepad" = "Manette";
+"phone" = "Téléphone";
+"web" = "Web";
+"joystick" = "Joystick";
+"game" = "Jeu";
+"dual" = "Double";
+"slow" = "Lent";
+"medium" = "Moyen";
+"fast" = "Rapide";
+"logData" = "Enregistrer les Données";
+"previewResolutionMedium" = "Résolution d'Aperçu (1280 x 720)";
+"previewResolutionLow" = "Résolution d'Aperçu (960 x 540)";
+"previewResolutionHigh" = "Résolution d'Aperçu (1920 x 1080)";
+"low" = "Basse";
+"high" = "Haute";
+"modelResolution" = "Résolution du Modèle ";
+"server" = "Serveur";
+"preview" = "Aperçu";
+"training" = "Entraînement";
+"sensorData" = "Données des Capteurs";
+"vehicle" = "Véhicule";
+"gps" = "GPS";
+"accelerometer" = "Accéléromètre";
+"magnetic" = "Champ Magnétique";
+"gyroscope" = "Gyroscope";
+"delay" = "Délai (ms)";
+"Autopilot" = "Pilote Automatique";
+"ObjectTracking" = "Suivi d'Objets";
+"autoMode" = "Mode Automatique";
+"model" = "Modèle";
+"input" = "Entrée";
+"device" = "Appareil";
+"threads" = "Threads";
+"object" = "Objet";
+"confidence" = "Confiance";
+"dynamicSpeed" = "Vitesse Dynamique";
+
+/* Settings */
+"camera" = "Caméra";
+"microphone" = "Microphone";
+"location" = "Localisation";
+"permission" = "Autorisations";
+"bluetooth" = "Bluetooth";
+"general" = "Général";
+"language" = "Langue";
+"languageSubtitle" = "Choisissez la langue d'affichage de l'app";
+"systemDefault" = "Langue du système";
+"applyingLanguage" = "Application de la langue…";
+
+/* Bluetooth Status */
+"connect" = "Connecter";
+"disconnect" = "Déconnecter";
+"connecting" = "Connexion en cours";
+"disconnecting" = "Déconnexion en cours";
+
+/* Model management */
+"modelDetails" = "Détails du Modèle";
+"name" = "Nom";
+"type" = "Type";
+"class" = "Classe";
+"inputOfModel" = "Entrée (l x h)";
+"tfliteLabel" = ".tflite";
+"cancel" = "Annuler";
+"done" = "Terminé";
+"file" = "Fichier";
+"url" = "URL";
+"addNewModel" = "Ajouter un Nouveau Modèle";
+
+/* Robot Info */
+"voltageDivider" = "Diviseur de Tension";
+"sonarText" = "Sonar";
+"bumperText" = "Pare-chocs";
+"wheelOdometer" = "Odométrie des Roues";
+"front" = "Avant";
+"back" = "Arrière";
+"led" = "LED";
+"indicatorText" = "Clignotants";
+"status" = "État";
+"motors" = "Moteurs";
+"forward" = "Avancer";
+"backward" = "Reculer";
+"stopLabel" = "Arrêter";
+"readings" = "Relevés";
+"battery" = "Batterie **.* V";
+"speedText" = "Vitesse (g,d) ***,*** tr/min";
+"sonarLabel" = "Sonar *** cm";
+"sendCommand" = "Envoyer des Commandes";
+"lightLabel" = "Lumières";
+
+/* Navigation */
+"setGoal" = "Définir l'Objectif";
+"setGoalText" = "Montez le téléphone sur le robot et \n indiquez un objectif. Le robot essaiera\n de l'atteindre après avoir appuyé sur démarrer.";
+"left" = "Gauche";
+"meter" = "[m]";
+"startLabel" = "DÉMARRER";
+"canceled" = "ANNULER";
+"info" = "Infos";
+"restart" = "Redémarrer";
+
+/* Settings > Permissions */
+"important" = "IMPORTANT";
+"cameraAccessRequiredMessage" = "OpenBot a besoin d'accéder à la caméra";
+"allowPermissionMessageFormat" = "Veuillez autoriser OpenBot à accéder à %@";
+"allowButtonFormat" = "Autoriser %@";
+
+/* Logout / open-code UI */
+"logOut" = "SE DÉCONNECTER";
+"confirmLogoutTitle" = "Confirmer la Déconnexion";
+"confirmLogoutMessage" = "Voulez-vous vraiment vous déconnecter ?";
+"codeExecuting" = "Votre code est en cours d'exécution..";
+
+/* Tab bar */
+"projectsTab" = "Projets";
+"homeTab" = "Accueil";
+"profileTab" = "Profil";

--- a/ios/OpenBot/OpenBot/fr.lproj/Localizable.strings
+++ b/ios/OpenBot/OpenBot/fr.lproj/Localizable.strings
@@ -128,3 +128,73 @@
 "projectsTab" = "Projets";
 "homeTab" = "Accueil";
 "profileTab" = "Profil";
+
+/* Loading / generic alerts */
+"loadingTitle" = "Chargement";
+"loadingProfileMessage" = "Veuillez patienter pendant le chargement du profil...";
+"loadingDataMessage" = "Veuillez patienter pendant le chargement des données...";
+"pleaseWaitMessage" = "Veuillez patienter...";
+"errorHeading" = "Erreur";
+"genericErrorMessage" = "Oups ! Une erreur s'est produite. Veuillez réessayer.";
+"okAction" = "OK";
+
+/* Profile screen */
+"myProfileHeading" = "Mon Profil";
+"setupProfilePromptLine1" = "Configurez votre profil en vous connectant avec";
+"setupProfilePromptLine2" = "votre compte Google.";
+"editProfile" = "Modifier le Profil";
+"logoutMenuItem" = "Déconnexion";
+"firstNameFieldLabel" = "Prénom";
+"lastNameFieldLabel" = "Nom";
+"dateOfBirthFieldLabel" = "Date de Naissance";
+"emailFieldLabel" = "E-mail";
+"unknownFallback" = "Inconnu";
+"saveChangesButton" = "Enregistrer les Modifications";
+"profileUpdatedSuccessToast" = "Profil mis à jour avec succès";
+"profilePictureLoadErrorToast" = "Erreur lors du chargement de la photo de profil";
+"signInWithGoogle" = "Se connecter avec Google";
+
+/* Project screen */
+"myProjectsHeading" = "Mes Projets";
+"pleaseSignInProjectsLine1" = "Veuillez vous connecter pour accéder à vos";
+"pleaseSignInProjectsLine2" = "projets.";
+"noProjectsFoundHeading" = "Oups ! Aucun projet trouvé.";
+"noProjectsFoundBody" = "Il semble qu'il n'y ait pas encore de projets\ndans votre Google Drive.";
+"deleteFileTitle" = "Supprimer ce fichier";
+"deleteFileMessage" = "Vous ne pourrez pas restaurer ce fichier plus tard";
+"deleteAction" = "Supprimer";
+
+/* QR Scanner / open-code bottom sheet */
+"scanQrCodeHeading" = "Scanner le Code QR";
+"scanInstructions" = "Placez le code QR dans le cadre pour le scanner. Évitez de bouger pour obtenir un résultat plus rapide.";
+"scanQrButton" = "Scanner QR";
+"qrScannerNavTitle" = "Scanner QR";
+"qrScanSuccessHeading" = "Code QR scanné avec succès";
+"qrFileDetectedMessageFormat" = "Fichier %@ détecté. Démarrage de l'exécution du code sur votre OpenBot.";
+"startButton" = "Démarrer";
+
+/* Playground (Run Robot / Blockly execution screen) */
+"cancelledStatus" = "Annulé";
+"stopRobotButton" = "Arrêter le Robot";
+"resetRobotButton" = "Réinitialiser le Robot";
+"stopCarButton" = "Arrêter le Véhicule";
+"playgroundNavTitle" = "Bac à Sable";
+
+/* Robot Info headings */
+"robotTypeHeading" = "Type de Robot";
+"sensorsHeading" = "Capteurs";
+"sonarReadingFormat" = "Sonar %@ cm";
+"batteryReadingFormat" = "Batterie %@ V";
+
+/* Point Goal Navigation */
+"goalReachedMessage" = "Objectif atteint";
+
+/* Model Management filter dropdown */
+"modelFilterAll" = "Tous";
+"modelFilterAllCaps" = "TOUS";
+"modelFilterAutoPilot" = "Pilote Automatique";
+"modelFilterDetector" = "Détecteur";
+"modelFilterNavigation" = "Navigation";
+
+/* Data Collection / Autopilot server dropdown default state */
+"noServer" = "Aucun Serveur";

--- a/ios/OpenBot/OpenBot/fr.lproj/Localizable.strings
+++ b/ios/OpenBot/OpenBot/fr.lproj/Localizable.strings
@@ -61,6 +61,8 @@
 "languageSubtitle" = "Choisissez la langue d'affichage de l'app";
 "systemDefault" = "Langue du système";
 "applyingLanguage" = "Application de la langue…";
+"webSignalingServer" = "Serveur de signalisation Web";
+"webSignalingServerPlaceholder" = "ws://192.168.1.40:8080/ws";
 
 /* Bluetooth Status */
 "connect" = "Connecter";

--- a/ios/OpenBot/OpenBot/hi.lproj/Localizable.strings
+++ b/ios/OpenBot/OpenBot/hi.lproj/Localizable.strings
@@ -128,3 +128,73 @@
 "projectsTab" = "प्रोजेक्ट्स";
 "homeTab" = "होम";
 "profileTab" = "प्रोफ़ाइल";
+
+/* Loading / generic alerts */
+"loadingTitle" = "लोड हो रहा है";
+"loadingProfileMessage" = "कृपया प्रतीक्षा करें, प्रोफ़ाइल लोड हो रही है...";
+"loadingDataMessage" = "कृपया प्रतीक्षा करें, डेटा लोड हो रहा है...";
+"pleaseWaitMessage" = "कृपया प्रतीक्षा करें...";
+"errorHeading" = "त्रुटि";
+"genericErrorMessage" = "उफ़! कुछ गलत हो गया। कृपया फिर से प्रयास करें।";
+"okAction" = "ठीक है";
+
+/* Profile screen */
+"myProfileHeading" = "मेरी प्रोफ़ाइल";
+"setupProfilePromptLine1" = "अपने Google खाते से साइन इन करके";
+"setupProfilePromptLine2" = "अपनी प्रोफ़ाइल सेट करें।";
+"editProfile" = "प्रोफ़ाइल संपादित करें";
+"logoutMenuItem" = "लॉग आउट";
+"firstNameFieldLabel" = "पहला नाम";
+"lastNameFieldLabel" = "अंतिम नाम";
+"dateOfBirthFieldLabel" = "जन्म तिथि";
+"emailFieldLabel" = "ईमेल";
+"unknownFallback" = "अज्ञात";
+"saveChangesButton" = "बदलाव सहेजें";
+"profileUpdatedSuccessToast" = "प्रोफ़ाइल सफलतापूर्वक अपडेट की गई";
+"profilePictureLoadErrorToast" = "प्रोफ़ाइल फ़ोटो लोड करने में त्रुटि";
+"signInWithGoogle" = "Google से साइन इन करें";
+
+/* Project screen */
+"myProjectsHeading" = "मेरे प्रोजेक्ट्स";
+"pleaseSignInProjectsLine1" = "अपने प्रोजेक्ट्स तक पहुँचने के लिए पहले";
+"pleaseSignInProjectsLine2" = "साइन इन करें।";
+"noProjectsFoundHeading" = "उफ़! कोई प्रोजेक्ट नहीं मिला।";
+"noProjectsFoundBody" = "ऐसा लगता है कि आपकी Google Drive में\nअभी तक कोई प्रोजेक्ट नहीं है।";
+"deleteFileTitle" = "इस फ़ाइल को हटाएँ";
+"deleteFileMessage" = "यह फ़ाइल बाद में पुनर्स्थापित नहीं की जा सकेगी";
+"deleteAction" = "हटाएँ";
+
+/* QR Scanner / open-code bottom sheet */
+"scanQrCodeHeading" = "क्यूआर कोड स्कैन करें";
+"scanInstructions" = "क्यूआर कोड को फ़्रेम के अंदर रखें और स्कैन करें। जल्दी परिणाम पाने के लिए फ़ोन को न हिलाएँ।";
+"scanQrButton" = "क्यूआर स्कैन करें";
+"qrScannerNavTitle" = "क्यूआर स्कैनर";
+"qrScanSuccessHeading" = "क्यूआर कोड सफलतापूर्वक स्कैन हुआ";
+"qrFileDetectedMessageFormat" = "%@ फ़ाइल मिली। आपके OpenBot पर कोड चलाना शुरू किया जा रहा है।";
+"startButton" = "शुरू करें";
+
+/* Playground (Run Robot / Blockly execution screen) */
+"cancelledStatus" = "रद्द किया गया";
+"stopRobotButton" = "रोबोट रोकें";
+"resetRobotButton" = "रोबोट रीसेट करें";
+"stopCarButton" = "वाहन रोकें";
+"playgroundNavTitle" = "प्लेग्राउंड";
+
+/* Robot Info headings */
+"robotTypeHeading" = "रोबोट प्रकार";
+"sensorsHeading" = "सेंसर";
+"sonarReadingFormat" = "सोनार %@ cm";
+"batteryReadingFormat" = "बैटरी %@ V";
+
+/* Point Goal Navigation */
+"goalReachedMessage" = "लक्ष्य तक पहुँच गए";
+
+/* Model Management filter dropdown */
+"modelFilterAll" = "सभी";
+"modelFilterAllCaps" = "सभी";
+"modelFilterAutoPilot" = "ऑटो पायलट";
+"modelFilterDetector" = "डिटेक्टर";
+"modelFilterNavigation" = "नेविगेशन";
+
+/* Data Collection / Autopilot server dropdown default state */
+"noServer" = "कोई सर्वर नहीं";

--- a/ios/OpenBot/OpenBot/hi.lproj/Localizable.strings
+++ b/ios/OpenBot/OpenBot/hi.lproj/Localizable.strings
@@ -61,6 +61,8 @@
 "languageSubtitle" = "ऐप की डिस्प्ले भाषा चुनें";
 "systemDefault" = "सिस्टम डिफ़ॉल्ट";
 "applyingLanguage" = "भाषा लागू की जा रही है…";
+"webSignalingServer" = "वेब सिग्नलिंग सर्वर";
+"webSignalingServerPlaceholder" = "ws://192.168.1.40:8080/ws";
 
 /* Bluetooth Status */
 "connect" = "कनेक्ट करें";

--- a/ios/OpenBot/OpenBot/hi.lproj/Localizable.strings
+++ b/ios/OpenBot/OpenBot/hi.lproj/Localizable.strings
@@ -1,0 +1,130 @@
+/* Screens */
+"OpenBot" = "OpenBot";
+"freeRoam" = "फ्री रोम";
+"dataCollection" = "डेटा संग्रहण";
+"controllerMapping" = "कंट्रोलर मैपिंग";
+"autoPilot" = "ऑटो पायलट";
+"objectTracking" = "ऑब्जेक्ट ट्रैकिंग";
+"modelManagement" = "मॉडल प्रबंधन";
+"robotInfo" = "रोबोट जानकारी";
+"navigation" = "लक्ष्य नेविगेशन";
+
+/* Misc */
+"controller" = "कंट्रोलर";
+"speed" = "गति";
+"driveMode" = "ड्राइव मोड";
+"gamepad" = "गेमपैड";
+"phone" = "फ़ोन";
+"web" = "वेब";
+"joystick" = "जॉयस्टिक";
+"game" = "गेम";
+"dual" = "ड्यूल";
+"slow" = "धीमी";
+"medium" = "मध्यम";
+"fast" = "तेज़";
+"logData" = "डेटा लॉग करें";
+"previewResolutionMedium" = "प्रीव्यू रिज़ॉल्यूशन (1280 x 720)";
+"previewResolutionLow" = "प्रीव्यू रिज़ॉल्यूशन (960 x 540)";
+"previewResolutionHigh" = "प्रीव्यू रिज़ॉल्यूशन (1920 x 1080)";
+"low" = "कम";
+"high" = "अधिक";
+"modelResolution" = "मॉडल रिज़ॉल्यूशन ";
+"server" = "सर्वर";
+"preview" = "प्रीव्यू";
+"training" = "प्रशिक्षण";
+"sensorData" = "सेंसर डेटा";
+"vehicle" = "वाहन";
+"gps" = "जीपीएस";
+"accelerometer" = "एक्सेलेरोमीटर";
+"magnetic" = "मैग्नेटिक सेंसर";
+"gyroscope" = "जायरोस्कोप";
+"delay" = "देरी (ms)";
+"Autopilot" = "ऑटो पायलट";
+"ObjectTracking" = "ऑब्जेक्ट ट्रैकिंग";
+"autoMode" = "ऑटो मोड";
+"model" = "मॉडल";
+"input" = "इनपुट";
+"device" = "डिवाइस";
+"threads" = "थ्रेड्स";
+"object" = "ऑब्जेक्ट";
+"confidence" = "कॉन्फिडेंस";
+"dynamicSpeed" = "डायनामिक स्पीड";
+
+/* Settings */
+"camera" = "कैमरा";
+"microphone" = "माइक्रोफ़ोन";
+"location" = "लोकेशन";
+"permission" = "अनुमतियाँ";
+"bluetooth" = "ब्लूटूथ";
+"general" = "सामान्य";
+"language" = "भाषा";
+"languageSubtitle" = "ऐप की डिस्प्ले भाषा चुनें";
+"systemDefault" = "सिस्टम डिफ़ॉल्ट";
+"applyingLanguage" = "भाषा लागू की जा रही है…";
+
+/* Bluetooth Status */
+"connect" = "कनेक्ट करें";
+"disconnect" = "डिस्कनेक्ट करें";
+"connecting" = "कनेक्ट हो रहा है";
+"disconnecting" = "डिस्कनेक्ट हो रहा है";
+
+/* Model management */
+"modelDetails" = "मॉडल विवरण";
+"name" = "नाम";
+"type" = "प्रकार";
+"class" = "क्लास";
+"inputOfModel" = "इनपुट (चौड़ाई x ऊँचाई)";
+"tfliteLabel" = ".tflite";
+"cancel" = "रद्द करें";
+"done" = "हो गया";
+"file" = "फ़ाइल";
+"url" = "URL";
+"addNewModel" = "नया मॉडल जोड़ें";
+
+/* Robot Info */
+"voltageDivider" = "वोल्टेज डिवाइडर";
+"sonarText" = "सोनार";
+"bumperText" = "बम्पर";
+"wheelOdometer" = "व्हील ओडोमेट्री";
+"front" = "आगे";
+"back" = "पीछे";
+"led" = "एलईडी";
+"indicatorText" = "इंडिकेटर";
+"status" = "स्थिति";
+"motors" = "मोटर्स";
+"forward" = "आगे बढ़ें";
+"backward" = "पीछे जाएँ";
+"stopLabel" = "रोकें";
+"readings" = "रीडिंग";
+"battery" = "बैटरी **.* V";
+"speedText" = "गति (बाएँ,दाएँ) ***,*** rpm";
+"sonarLabel" = "सोनार *** cm";
+"sendCommand" = "कमांड भेजें";
+"lightLabel" = "लाइट्स";
+
+/* Navigation */
+"setGoal" = "लक्ष्य निर्धारित करें";
+"setGoalText" = "फ़ोन को रोबोट पर लगाएँ और \n एक लक्ष्य निर्धारित करें। स्टार्ट दबाने के बाद\n रोबोट लक्ष्य तक पहुँचने की कोशिश करेगा।";
+"left" = "बाएँ";
+"meter" = "[मी.]";
+"startLabel" = "शुरू करें";
+"canceled" = "रद्द करें";
+"info" = "जानकारी";
+"restart" = "पुनः आरंभ करें";
+
+/* Settings > Permissions */
+"important" = "महत्वपूर्ण";
+"cameraAccessRequiredMessage" = "OpenBot को कैमरे की अनुमति चाहिए";
+"allowPermissionMessageFormat" = "कृपया OpenBot को %@ का एक्सेस दें";
+"allowButtonFormat" = "%@ की अनुमति दें";
+
+/* Logout / open-code UI */
+"logOut" = "लॉग आउट";
+"confirmLogoutTitle" = "लॉगआउट की पुष्टि करें";
+"confirmLogoutMessage" = "क्या आप वाकई लॉग आउट करना चाहते हैं?";
+"codeExecuting" = "आपका कोड चल रहा है..";
+
+/* Tab bar */
+"projectsTab" = "प्रोजेक्ट्स";
+"homeTab" = "होम";
+"profileTab" = "प्रोफ़ाइल";

--- a/ios/OpenBot/OpenBot/ko.lproj/Localizable.strings
+++ b/ios/OpenBot/OpenBot/ko.lproj/Localizable.strings
@@ -61,6 +61,8 @@
 "languageSubtitle" = "앱 표시 언어를 선택하세요";
 "systemDefault" = "시스템 기본값";
 "applyingLanguage" = "언어 적용 중…";
+"webSignalingServer" = "웹 시그널링 서버";
+"webSignalingServerPlaceholder" = "ws://192.168.1.40:8080/ws";
 
 /* Bluetooth Status */
 "connect" = "연결";

--- a/ios/OpenBot/OpenBot/ko.lproj/Localizable.strings
+++ b/ios/OpenBot/OpenBot/ko.lproj/Localizable.strings
@@ -1,0 +1,130 @@
+/* Screens */
+"OpenBot" = "OpenBot";
+"freeRoam" = "자유 주행";
+"dataCollection" = "데이터 수집";
+"controllerMapping" = "컨트롤러 매핑";
+"autoPilot" = "자율 주행";
+"objectTracking" = "물체 추적";
+"modelManagement" = "모델 관리";
+"robotInfo" = "로봇 정보";
+"navigation" = "목표 지점 내비게이션";
+
+/* Misc */
+"controller" = "컨트롤러";
+"speed" = "속도";
+"driveMode" = "주행 모드";
+"gamepad" = "게임패드";
+"phone" = "휴대폰";
+"web" = "웹";
+"joystick" = "조이스틱";
+"game" = "게임";
+"dual" = "듀얼";
+"slow" = "느림";
+"medium" = "보통";
+"fast" = "빠름";
+"logData" = "데이터 기록";
+"previewResolutionMedium" = "미리보기 해상도 (1280 x 720)";
+"previewResolutionLow" = "미리보기 해상도 (960 x 540)";
+"previewResolutionHigh" = "미리보기 해상도 (1920 x 1080)";
+"low" = "낮음";
+"high" = "높음";
+"modelResolution" = "모델 해상도 ";
+"server" = "서버";
+"preview" = "미리보기";
+"training" = "학습";
+"sensorData" = "센서 데이터";
+"vehicle" = "차량";
+"gps" = "GPS";
+"accelerometer" = "가속도계";
+"magnetic" = "지자기 센서";
+"gyroscope" = "자이로스코프";
+"delay" = "지연 시간 (ms)";
+"Autopilot" = "자율 주행";
+"ObjectTracking" = "물체 추적";
+"autoMode" = "자동 모드";
+"model" = "모델";
+"input" = "입력";
+"device" = "디바이스";
+"threads" = "스레드";
+"object" = "물체";
+"confidence" = "신뢰도";
+"dynamicSpeed" = "동적 속도";
+
+/* Settings */
+"camera" = "카메라";
+"microphone" = "마이크";
+"location" = "위치";
+"permission" = "권한";
+"bluetooth" = "블루투스";
+"general" = "일반";
+"language" = "언어";
+"languageSubtitle" = "앱 표시 언어를 선택하세요";
+"systemDefault" = "시스템 기본값";
+"applyingLanguage" = "언어 적용 중…";
+
+/* Bluetooth Status */
+"connect" = "연결";
+"disconnect" = "연결 해제";
+"connecting" = "연결 중";
+"disconnecting" = "연결 해제 중";
+
+/* Model management */
+"modelDetails" = "모델 상세 정보";
+"name" = "이름";
+"type" = "유형";
+"class" = "클래스";
+"inputOfModel" = "입력 (가로 x 세로)";
+"tfliteLabel" = ".tflite";
+"cancel" = "취소";
+"done" = "완료";
+"file" = "파일";
+"url" = "URL";
+"addNewModel" = "새 모델 추가";
+
+/* Robot Info */
+"voltageDivider" = "전압 분배기";
+"sonarText" = "소나";
+"bumperText" = "범퍼";
+"wheelOdometer" = "휠 오도메트리";
+"front" = "전면";
+"back" = "후면";
+"led" = "LED";
+"indicatorText" = "방향지시등";
+"status" = "상태";
+"motors" = "모터";
+"forward" = "전진";
+"backward" = "후진";
+"stopLabel" = "정지";
+"readings" = "측정값";
+"battery" = "배터리 **.* V";
+"speedText" = "속도 (좌,우) ***,*** rpm";
+"sonarLabel" = "소나 *** cm";
+"sendCommand" = "명령 전송";
+"lightLabel" = "조명";
+
+/* Navigation */
+"setGoal" = "목표 설정";
+"setGoalText" = "휴대폰을 로봇에 장착하고 \n 목표를 지정하세요. 시작을 누르면\n 로봇이 목표에 도달하려고 시도합니다.";
+"left" = "왼쪽";
+"meter" = "[m]";
+"startLabel" = "시작";
+"canceled" = "취소";
+"info" = "정보";
+"restart" = "다시 시작";
+
+/* Settings > Permissions */
+"important" = "중요";
+"cameraAccessRequiredMessage" = "OpenBot에 카메라 접근 권한이 필요합니다";
+"allowPermissionMessageFormat" = "OpenBot이 %@에 접근하도록 허용해 주세요";
+"allowButtonFormat" = "%@ 허용";
+
+/* Logout / open-code UI */
+"logOut" = "로그아웃";
+"confirmLogoutTitle" = "로그아웃 확인";
+"confirmLogoutMessage" = "정말 로그아웃하시겠습니까?";
+"codeExecuting" = "코드를 실행하는 중입니다..";
+
+/* Tab bar */
+"projectsTab" = "프로젝트";
+"homeTab" = "홈";
+"profileTab" = "프로필";

--- a/ios/OpenBot/OpenBot/ko.lproj/Localizable.strings
+++ b/ios/OpenBot/OpenBot/ko.lproj/Localizable.strings
@@ -128,3 +128,73 @@
 "projectsTab" = "프로젝트";
 "homeTab" = "홈";
 "profileTab" = "프로필";
+
+/* Loading / generic alerts */
+"loadingTitle" = "불러오는 중";
+"loadingProfileMessage" = "프로필을 불러오는 중입니다...";
+"loadingDataMessage" = "데이터를 불러오는 중입니다...";
+"pleaseWaitMessage" = "잠시만 기다려 주세요...";
+"errorHeading" = "오류";
+"genericErrorMessage" = "이런! 문제가 발생했습니다. 다시 시도해 주세요.";
+"okAction" = "확인";
+
+/* Profile screen */
+"myProfileHeading" = "내 프로필";
+"setupProfilePromptLine1" = "다음으로 로그인하여";
+"setupProfilePromptLine2" = "프로필을 설정하세요: Google 계정.";
+"editProfile" = "프로필 편집";
+"logoutMenuItem" = "로그아웃";
+"firstNameFieldLabel" = "이름";
+"lastNameFieldLabel" = "성";
+"dateOfBirthFieldLabel" = "생년월일";
+"emailFieldLabel" = "이메일";
+"unknownFallback" = "알 수 없음";
+"saveChangesButton" = "변경 사항 저장";
+"profileUpdatedSuccessToast" = "프로필이 성공적으로 업데이트되었습니다";
+"profilePictureLoadErrorToast" = "프로필 사진을 불러오지 못했습니다";
+"signInWithGoogle" = "Google 계정으로 로그인";
+
+/* Project screen */
+"myProjectsHeading" = "내 프로젝트";
+"pleaseSignInProjectsLine1" = "프로젝트에 접근하려면 먼저";
+"pleaseSignInProjectsLine2" = "로그인해 주세요.";
+"noProjectsFoundHeading" = "이런! 프로젝트를 찾을 수 없습니다.";
+"noProjectsFoundBody" = "아직 Google 드라이브에\n프로젝트가 없는 것 같습니다.";
+"deleteFileTitle" = "이 파일 삭제";
+"deleteFileMessage" = "이 파일은 나중에 복원할 수 없습니다";
+"deleteAction" = "삭제";
+
+/* QR Scanner / open-code bottom sheet */
+"scanQrCodeHeading" = "QR 코드 스캔";
+"scanInstructions" = "QR 코드를 프레임 안에 놓고 스캔하세요. 빠른 인식을 위해 흔들지 마세요.";
+"scanQrButton" = "QR 스캔";
+"qrScannerNavTitle" = "QR 스캐너";
+"qrScanSuccessHeading" = "QR 코드 스캔 성공";
+"qrFileDetectedMessageFormat" = "%@ 파일이 감지되었습니다. OpenBot에서 코드 실행을 시작합니다.";
+"startButton" = "시작";
+
+/* Playground (Run Robot / Blockly execution screen) */
+"cancelledStatus" = "취소됨";
+"stopRobotButton" = "로봇 정지";
+"resetRobotButton" = "로봇 초기화";
+"stopCarButton" = "차량 정지";
+"playgroundNavTitle" = "플레이그라운드";
+
+/* Robot Info headings */
+"robotTypeHeading" = "로봇 유형";
+"sensorsHeading" = "센서";
+"sonarReadingFormat" = "소나 %@ cm";
+"batteryReadingFormat" = "배터리 %@ V";
+
+/* Point Goal Navigation */
+"goalReachedMessage" = "목표 도달";
+
+/* Model Management filter dropdown */
+"modelFilterAll" = "전체";
+"modelFilterAllCaps" = "전체";
+"modelFilterAutoPilot" = "자율 주행";
+"modelFilterDetector" = "감지기";
+"modelFilterNavigation" = "내비게이션";
+
+/* Data Collection / Autopilot server dropdown default state */
+"noServer" = "서버 없음";

--- a/ios/OpenBot/OpenBot/zh-Hans.lproj/Localizable.strings
+++ b/ios/OpenBot/OpenBot/zh-Hans.lproj/Localizable.strings
@@ -128,3 +128,73 @@
 "projectsTab" = "项目";
 "homeTab" = "首页";
 "profileTab" = "我的";
+
+/* Loading / generic alerts */
+"loadingTitle" = "加载中";
+"loadingProfileMessage" = "正在加载个人资料，请稍候…";
+"loadingDataMessage" = "正在加载数据，请稍候…";
+"pleaseWaitMessage" = "请稍候…";
+"errorHeading" = "错误";
+"genericErrorMessage" = "哎呀，出了点问题，请重试。";
+"okAction" = "确定";
+
+/* Profile screen */
+"myProfileHeading" = "我的资料";
+"setupProfilePromptLine1" = "登录你的";
+"setupProfilePromptLine2" = "Google 账号以设置个人资料。";
+"editProfile" = "编辑资料";
+"logoutMenuItem" = "退出登录";
+"firstNameFieldLabel" = "名";
+"lastNameFieldLabel" = "姓";
+"dateOfBirthFieldLabel" = "出生日期";
+"emailFieldLabel" = "邮箱";
+"unknownFallback" = "未知";
+"saveChangesButton" = "保存更改";
+"profileUpdatedSuccessToast" = "资料更新成功";
+"profilePictureLoadErrorToast" = "加载头像失败";
+"signInWithGoogle" = "使用 Google 账号登录";
+
+/* Project screen */
+"myProjectsHeading" = "我的项目";
+"pleaseSignInProjectsLine1" = "请先登录以访问你的";
+"pleaseSignInProjectsLine2" = "项目。";
+"noProjectsFoundHeading" = "哎呀，未找到项目。";
+"noProjectsFoundBody" = "你的 Google 云端硬盘中\n似乎还没有项目。";
+"deleteFileTitle" = "删除此文件";
+"deleteFileMessage" = "此文件删除后将无法恢复";
+"deleteAction" = "删除";
+
+/* QR Scanner / open-code bottom sheet */
+"scanQrCodeHeading" = "扫描二维码";
+"scanInstructions" = "将二维码置于框内进行扫描，请勿晃动手机以便更快获得结果。";
+"scanQrButton" = "扫描二维码";
+"qrScannerNavTitle" = "二维码扫描";
+"qrScanSuccessHeading" = "二维码扫描成功";
+"qrFileDetectedMessageFormat" = "检测到文件 %@，即将在你的 OpenBot 上开始执行代码。";
+"startButton" = "开始";
+
+/* Playground (Run Robot / Blockly execution screen) */
+"cancelledStatus" = "已取消";
+"stopRobotButton" = "停止机器人";
+"resetRobotButton" = "重置机器人";
+"stopCarButton" = "停止小车";
+"playgroundNavTitle" = "练习场";
+
+/* Robot Info headings */
+"robotTypeHeading" = "机器人类型";
+"sensorsHeading" = "传感器";
+"sonarReadingFormat" = "声呐 %@ 厘米";
+"batteryReadingFormat" = "电池 %@ V";
+
+/* Point Goal Navigation */
+"goalReachedMessage" = "已到达目标";
+
+/* Model Management filter dropdown */
+"modelFilterAll" = "全部";
+"modelFilterAllCaps" = "全部";
+"modelFilterAutoPilot" = "自动驾驶";
+"modelFilterDetector" = "检测器";
+"modelFilterNavigation" = "导航";
+
+/* Data Collection / Autopilot server dropdown default state */
+"noServer" = "无服务器";

--- a/ios/OpenBot/OpenBot/zh-Hans.lproj/Localizable.strings
+++ b/ios/OpenBot/OpenBot/zh-Hans.lproj/Localizable.strings
@@ -1,0 +1,130 @@
+/* Screens */
+"OpenBot" = "OpenBot";
+"freeRoam" = "自由漫游";
+"dataCollection" = "数据采集";
+"controllerMapping" = "控制器映射";
+"autoPilot" = "自动驾驶";
+"objectTracking" = "物体追踪";
+"modelManagement" = "模型管理";
+"robotInfo" = "机器人信息";
+"navigation" = "目标点导航";
+
+/* Misc */
+"controller" = "控制器";
+"speed" = "速度";
+"driveMode" = "驾驶模式";
+"gamepad" = "游戏手柄";
+"phone" = "手机";
+"web" = "网页";
+"joystick" = "摇杆";
+"game" = "游戏";
+"dual" = "双控";
+"slow" = "慢速";
+"medium" = "中速";
+"fast" = "快速";
+"logData" = "记录数据";
+"previewResolutionMedium" = "预览分辨率 (1280 x 720)";
+"previewResolutionLow" = "预览分辨率 (960 x 540)";
+"previewResolutionHigh" = "预览分辨率 (1920 x 1080)";
+"low" = "低";
+"high" = "高";
+"modelResolution" = "模型分辨率 ";
+"server" = "服务器";
+"preview" = "预览";
+"training" = "训练";
+"sensorData" = "传感器数据";
+"vehicle" = "车辆";
+"gps" = "GPS";
+"accelerometer" = "加速度计";
+"magnetic" = "磁力计";
+"gyroscope" = "陀螺仪";
+"delay" = "延迟 (毫秒)";
+"Autopilot" = "自动驾驶";
+"ObjectTracking" = "物体追踪";
+"autoMode" = "自动模式";
+"model" = "模型";
+"input" = "输入";
+"device" = "设备";
+"threads" = "线程数";
+"object" = "物体";
+"confidence" = "置信度";
+"dynamicSpeed" = "动态速度";
+
+/* Settings */
+"camera" = "相机";
+"microphone" = "麦克风";
+"location" = "位置";
+"permission" = "权限";
+"bluetooth" = "蓝牙";
+"general" = "通用";
+"language" = "语言";
+"languageSubtitle" = "选择应用的显示语言";
+"systemDefault" = "系统默认";
+"applyingLanguage" = "正在应用语言…";
+
+/* Bluetooth Status */
+"connect" = "连接";
+"disconnect" = "断开连接";
+"connecting" = "正在连接";
+"disconnecting" = "正在断开";
+
+/* Model management */
+"modelDetails" = "模型详情";
+"name" = "名称";
+"type" = "类型";
+"class" = "类别";
+"inputOfModel" = "输入 (宽 x 高)";
+"tfliteLabel" = ".tflite";
+"cancel" = "取消";
+"done" = "完成";
+"file" = "文件";
+"url" = "URL";
+"addNewModel" = "添加新模型";
+
+/* Robot Info */
+"voltageDivider" = "分压器";
+"sonarText" = "声呐";
+"bumperText" = "保险杠";
+"wheelOdometer" = "车轮里程计";
+"front" = "前";
+"back" = "后";
+"led" = "指示灯";
+"indicatorText" = "转向灯";
+"status" = "状态";
+"motors" = "电机";
+"forward" = "前进";
+"backward" = "后退";
+"stopLabel" = "停止";
+"readings" = "读数";
+"battery" = "电池 **.* V";
+"speedText" = "速度 (左,右) ***,*** 转/分";
+"sonarLabel" = "声呐 *** 厘米";
+"sendCommand" = "发送指令";
+"lightLabel" = "灯光";
+
+/* Navigation */
+"setGoal" = "设置目标";
+"setGoalText" = "将手机安装到机器人上，\n 设置一个目标位置。按下开始后，\n 机器人将尝试到达该目标。";
+"left" = "左";
+"meter" = "[米]";
+"startLabel" = "开始";
+"canceled" = "取消";
+"info" = "信息";
+"restart" = "重新开始";
+
+/* Settings > Permissions */
+"important" = "重要提示";
+"cameraAccessRequiredMessage" = "OpenBot 需要访问相机权限";
+"allowPermissionMessageFormat" = "请允许 OpenBot 访问%@";
+"allowButtonFormat" = "允许访问%@";
+
+/* Logout / open-code UI */
+"logOut" = "退出登录";
+"confirmLogoutTitle" = "确认退出登录";
+"confirmLogoutMessage" = "确定要退出登录吗？";
+"codeExecuting" = "代码正在执行中……";
+
+/* Tab bar */
+"projectsTab" = "项目";
+"homeTab" = "首页";
+"profileTab" = "我的";

--- a/ios/OpenBot/OpenBot/zh-Hans.lproj/Localizable.strings
+++ b/ios/OpenBot/OpenBot/zh-Hans.lproj/Localizable.strings
@@ -61,6 +61,8 @@
 "languageSubtitle" = "选择应用的显示语言";
 "systemDefault" = "系统默认";
 "applyingLanguage" = "正在应用语言…";
+"webSignalingServer" = "网页信令服务器";
+"webSignalingServerPlaceholder" = "ws://192.168.1.40:8080/ws";
 
 /* Bluetooth Status */
 "connect" = "连接";

--- a/ios/OpenBot/Podfile
+++ b/ios/OpenBot/Podfile
@@ -32,7 +32,7 @@ end
 post_install do |installer|
   installer.pods_project.targets.each do |target|
     target.build_configurations.each do |config|
-      config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '13.0'
+      config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '14.0'
     end
   end
 end


### PR DESCRIPTION
1. Added an in-app language picker (Settings → General → Language) with flag emoji for System Default, English, German, Spanish, French, Chinese, Korean, and Hindi.
2. Language switches live with a branded transition — no app restart needed.                                                                                             
3. Built full localization infrastructure from scratch (Localizable.strings for all 7 languages) — the app previously had none.                                          
4. Translated the entire app: Home, Settings, Profile, Projects, QR Scanner, Data Collection, Autopilot, Object Tracking, Robot Info, Navigation, and Playground screens.
5. Redesigned the Settings screen with section headers, icon-right rows, and the new Language row.                                                                       
6. Fixed Home screen tiles and tab bar titles (Projects/Profile) getting stuck in the original language after switching.                                                 
7. Fixed text truncation across multiple screens caused by label widths estimated from character count instead of real rendered width.                                   
8. Fixed off-center/truncated sign-in text and overlapping toggle labels ("Auto Mode", "Log Data") for longer translations.                                              
9. Made the Bluetooth Settings icon consistent with the one used on the Home screen.